### PR TITLE
Change base URL to /pj/zudo-pd/ for takazudomodular.com integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ This is a hardware project for designing a USB-PD powered modular synthesizer po
 
 The documentation is automatically deployed to Netlify:
 
-- **Production URL**: https://zudopd.netlify.app/
+- **Production URL**: https://takazudomodular.com/pj/zudo-pd/
+- **Netlify URL**: https://manual-oxi-one-mk2.netlify.app/pj/zudo-pd/ (rewritten to production URL)
+- **Base Path**: `/pj/zudo-pd/`
 - **Deployment**: Automatic on every push to `main` branch
 - **Technology**: Docusaurus static site deployed via Netlify CLI on GitHub Actions
 - **Configuration**: See `.github/workflows/main-deploy.yml` for deployment workflow
@@ -86,19 +88,19 @@ Use English for all text to ensure international accessibility and collaboration
 
 ## URL Reference Guidelines
 
-When the user provides URLs starting with `http://localhost:3800/` or `http://zudopd.localhost:3800/` in the conversation:
+When the user provides URLs starting with `http://localhost:3800/pj/zudo-pd/` or `http://zudopd.localhost:3800/pj/zudo-pd/` in the conversation:
 
 - **DO NOT fetch the URL** - These are local documentation URLs served by Docusaurus
 - **Instead, find and read the corresponding markdown file** in the `/doc/` directory
-- Map URLs to file paths following Docusaurus routing:
-  - `http://localhost:3800/` or `http://zudopd.localhost:3800/` → `/doc/docs/` (root pages)
-  - `http://zudopd.localhost:3800/docs/inbox/overview` → `/doc/docs/inbox/overview.md`
-  - `http://zudopd.localhost:3800/docs/inbox/circuit-diagrams` → `/doc/docs/inbox/circuit-diagrams.md`
+- Map URLs to file paths following Docusaurus routing (note: `/pj/zudo-pd/` is the base path):
+  - `http://localhost:3800/pj/zudo-pd/` or `http://zudopd.localhost:3800/pj/zudo-pd/` → `/doc/docs/` (root pages)
+  - `http://zudopd.localhost:3800/pj/zudo-pd/docs/inbox/overview` → `/doc/docs/inbox/overview.md`
+  - `http://zudopd.localhost:3800/pj/zudo-pd/docs/inbox/circuit-diagrams` → `/doc/docs/inbox/circuit-diagrams.md`
 - Use the Read tool to access the actual markdown source files
 - This provides the raw content without HTML rendering, making it easier to edit and understand
 
 Example:
-- User mentions: `http://zudopd.localhost:3800/docs/inbox/current-status`
+- User mentions: `http://zudopd.localhost:3800/pj/zudo-pd/docs/inbox/current-status`
 - Read file: `/doc/docs/inbox/current-status.md`
 
 ## File Types

--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -13,8 +13,8 @@ const config = {
   },
 
   // Set the production url of your site here
-  url: 'https://zudo-power-usb-pd.example.com',
-  baseUrl: '/',
+  url: 'https://takazudomodular.com',
+  baseUrl: '/pj/zudo-pd/',
 
   // Don't add trailing slash
   trailingSlash: false,

--- a/doc/src/pages/index.tsx
+++ b/doc/src/pages/index.tsx
@@ -1,12 +1,14 @@
 import type { ReactNode } from 'react';
 import clsx from 'clsx';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import DocsSitemap from '@site/src/components/DocsSitemap';
 import styles from './index.module.css';
 
 export default function Home(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
+  const logoUrl = useBaseUrl('/img/logo.svg');
   return (
     <Layout title={siteConfig.title}>
       <main className={clsx(styles.main)}>
@@ -21,11 +23,7 @@ export default function Home(): ReactNode {
 
                 {/* Big Logo */}
                 <div className={styles.logoContainer}>
-                  <img
-                    src="/img/logo.svg"
-                    alt="USB-PD Synth Power Logo"
-                    className={styles.bigLogo}
-                  />
+                  <img src={logoUrl} alt="USB-PD Synth Power Logo" className={styles.bigLogo} />
                 </div>
               </div>
 

--- a/doc/static/netlify.toml
+++ b/doc/static/netlify.toml
@@ -1,0 +1,26 @@
+# Netlify configuration for zudo-PD documentation
+# Serves content at /pj/zudo-pd/ base path
+
+[build]
+  publish = "build"
+
+# Redirect root to the base path
+[[redirects]]
+  from = "/"
+  to = "/pj/zudo-pd/"
+  status = 301
+  force = true
+
+# Rewrite all requests under /pj/zudo-pd/ to serve files from root
+[[redirects]]
+  from = "/pj/zudo-pd/*"
+  to = "/:splat"
+  status = 200
+  force = true
+
+# Handle trailing slash requests
+[[redirects]]
+  from = "/pj/zudo-pd"
+  to = "/pj/zudo-pd/"
+  status = 301
+  force = true


### PR DESCRIPTION
## Summary
- Configure Docusaurus to serve documentation at `/pj/zudo-pd/` path instead of root
- Add Netlify redirects to handle the new base path
- Fix logo path to use `useBaseUrl` hook for proper path resolution
- Update CLAUDE.md with new deployment URLs

## Changes
- `doc/docusaurus.config.js`: Set `url` to `https://takazudomodular.com` and `baseUrl` to `/pj/zudo-pd/`
- `doc/static/netlify.toml`: New file with redirects to serve content at `/pj/zudo-pd/`
- `doc/src/pages/index.tsx`: Use `useBaseUrl` hook for logo path
- `CLAUDE.md`: Document new production URL and base path

## Test plan
- [ ] Verify dev server runs at `http://zudopd.localhost:3800/pj/zudo-pd/`
- [ ] Verify all internal links work correctly with new base path
- [ ] Deploy and verify `https://manual-oxi-one-mk2.netlify.app/pj/zudo-pd/` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)