### PR TITLE
Update header: remove title logo, add Takazudo Modular link

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -110,7 +110,7 @@ const config = {
             type: 'html',
             position: 'right',
             value:
-              '<a href="https://takazudomodular.com/" class="navbar__takazudo-modular"><img src="/pj/zudo-pd/img/logo.svg" alt="Takazudo Modular" /><span>Takazudo Modular</span></a>',
+              '<a href="https://takazudomodular.com/" class="navbar__takazudo-modular" rel="noopener noreferrer"><img src="/pj/zudo-pd/img/logo.svg" alt="" /><span>Takazudo Modular</span></a>',
           },
         ],
       },

--- a/doc/src/css/custom.css
+++ b/doc/src/css/custom.css
@@ -265,14 +265,15 @@ article.theme-doc-markdown {
   gap: 0.5rem;
   color: var(--ifm-navbar-link-color);
   text-decoration: none;
-  font-family: Futura, sans-serif;
+  font-family: Futura, 'Century Gothic', 'Trebuchet MS', Arial, sans-serif;
   font-weight: var(--ifm-font-weight-semibold);
   transition: color var(--ifm-transition-fast);
 }
 
-.navbar__takazudo-modular:hover {
+.navbar__takazudo-modular:hover,
+.navbar__takazudo-modular:focus-visible {
   color: var(--ifm-color-primary);
-  text-decoration: none;
+  outline: none;
 }
 
 .navbar__takazudo-modular img {


### PR DESCRIPTION
## Summary
- Remove logo from navbar left side (keep title text only)
- Add Takazudo Modular link with logo on right side of header
- Style with Futura font, white logo that stays white on hover

## Test plan
- [ ] Verify header no longer shows logo on left side
- [ ] Verify "Takazudo Modular" link appears on right side with logo
- [ ] Verify link points to https://takazudomodular.com/
- [ ] Verify hover state shows primary color text, white logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)