### PR TITLE
chore(deploy): enable Cloudflare production deploy at pd.takazudomodular.com

### DIFF
--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -184,20 +184,24 @@ connection destinations, and signal/voltage levels.
 All documentation must be written in **English** (content, diagrams, labels,
 commit messages) for international accessibility.
 
-## Cloudflare Go-Live Checklist (manual, out-of-band)
+## Cloudflare Deploy (live)
 
-The deploy workflow stays a no-op (build only) until these are done:
+Go-live is complete — pushes to `main` build **and publish** the site to
+Cloudflare Workers static assets at **https://pd.takazudomodular.com**.
 
-1. **Add GitHub Actions secrets** (repo Settings → Secrets and variables →
-   Actions):
+What is wired up:
+
+1. **GitHub Actions secrets** (repo Settings → Secrets and variables → Actions):
    - `CLOUDFLARE_API_TOKEN` — token with **Workers: Edit** permission
-   - `CLOUDFLARE_ACCOUNT_ID` — your Cloudflare account id
-2. **Set the real docs subdomain** in `doc/wrangler.toml`
-   (`[[env.production.routes]]` → `pattern`), replacing the `REPLACE_ME`
-   placeholder. The apex `takazudomodular.com` is used by the main site, so use
-   a docs subdomain, e.g. `pd.takazudomodular.com`. Keep `siteUrl` in
-   `src/config/settings.ts` in sync.
-3. **Bind the custom domain** in Cloudflare (Workers → your worker → Settings →
-   Domains & Routes → Add custom domain) and ensure DNS for the subdomain is on
-   Cloudflare.
-4. Push to `main` — the deploy job now runs and publishes the site.
+   - `CLOUDFLARE_ACCOUNT_ID` — the Cloudflare account id
+2. **Docs subdomain** is set in `doc/wrangler.toml`
+   (`[[env.production.routes]]` → `pattern = "pd.takazudomodular.com"`). The apex
+   `takazudomodular.com` is the main site, so docs live on the `pd.` subdomain.
+   `siteUrl` in `src/config/settings.ts` is kept in sync.
+3. **Custom domain** — `custom_domain = true` makes wrangler provision the
+   Workers custom domain + DNS record automatically (the `takazudomodular.com`
+   zone must be on the same Cloudflare account as `CLOUDFLARE_ACCOUNT_ID`).
+
+The deploy job in `.github/workflows/main-deploy.yml` still self-guards: it skips
+the publish (build-only) if either secret is missing or `wrangler.toml` is
+reverted to the placeholder token, so `main` stays green either way.

--- a/doc/wrangler.toml
+++ b/doc/wrangler.toml
@@ -31,18 +31,20 @@ not_found_handling = "404-page"
 # ---------------------------------------------------------------------------
 # Production custom-domain route (deployed via `wrangler deploy --env production`).
 #
-# !! PLACEHOLDER !! — `REPLACE_ME` below must be changed to the real docs
-# subdomain before the first production deploy. The apex `takazudomodular.com`
-# is used by the main site, so use a docs subdomain, e.g. `pd.takazudomodular.com`.
-# Then bind that subdomain as a Cloudflare custom domain (Workers → your worker
-# → Settings → Domains & Routes → Add custom domain).
+# custom_domain = true tells wrangler to provision the Workers custom domain and
+# its DNS record automatically on first deploy. This requires the
+# takazudomodular.com zone to live on the same Cloudflare account as
+# CLOUDFLARE_ACCOUNT_ID. The apex takazudomodular.com is the main site, so the
+# docs are served from the pd. subdomain.
 #
-# The deploy job in .github/workflows/main-deploy.yml greps for `REPLACE_ME`
-# and SKIPS the deploy while the placeholder is unreplaced, so the merge to
-# main stays green until go-live config is complete.
+# Keep this hostname in sync with siteUrl in src/config/settings.ts.
 # account_id is intentionally omitted — wrangler reads CLOUDFLARE_ACCOUNT_ID
 # from the environment.
+#
+# NOTE: the deploy job in .github/workflows/main-deploy.yml skips the publish
+# while this file still contains the literal domain placeholder token, so do not
+# reintroduce that token here.
 # ---------------------------------------------------------------------------
 [[env.production.routes]]
-pattern = "REPLACE_ME.takazudomodular.com"
+pattern = "pd.takazudomodular.com"
 custom_domain = true


### PR DESCRIPTION
## Summary

Repo Cloudflare secrets are now set, so this flips the **last go-live gate** for the zudo-doc site. After this merges, every push to \`main\` will **build and publish** the docs to Cloudflare Workers static assets at **https://pd.takazudomodular.com** (previously the deploy job ran build-only and skipped the publish).

## Changes

- **\`doc/wrangler.toml\`** — production route set to \`pd.takazudomodular.com\`; removed the placeholder token from the route **and the comments** (the deploy gate greps the whole file, so a leftover token in a comment would keep the publish skipped). \`custom_domain = true\` makes wrangler provision the Workers custom domain + DNS record on first deploy.
- **\`doc/CLAUDE.md\`** — rewrote the go-live checklist to reflect the now-live state.

## Gate / safety

The deploy job in \`main-deploy.yml\` stays self-guarded: it falls back to build-only if either CF secret is missing or the placeholder token reappears, so \`main\` stays green regardless.

## Verification after merge

- Deploy workflow run goes green with the publish step **executing** (not skipped).
- \`https://pd.takazudomodular.com\` serves the site (custom domain + cert may take a few minutes on first provision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)