### PR TITLE
chore(doc): bump zfb next.49 + zudo-doc 0.2.9, wire dual-theme code highlighting

### DIFF
--- a/doc/package.json
+++ b/doc/package.json
@@ -12,10 +12,10 @@
     "b4push": "pnpm check && pnpm build"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.41",
-    "@takazudo/zfb-runtime": "0.1.0-next.41",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.41",
-    "@takazudo/zudo-doc": "^0.2.4",
+    "@takazudo/zfb": "0.1.0-next.49",
+    "@takazudo/zfb-runtime": "0.1.0-next.49",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.49",
+    "@takazudo/zudo-doc": "^0.2.9",
     "zod": "^4.0.0",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -29,7 +29,7 @@
     "katex": "^0.16.38",
     "minisearch": "^7.2.0",
     "diff": "^8.0.3",
-    "@takazudo/zudo-doc-history-server": "^0.2.4"
+    "@takazudo/zudo-doc-history-server": "^0.2.9"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/doc/pnpm-lock.yaml
+++ b/doc/pnpm-lock.yaml
@@ -12,20 +12,20 @@ importers:
         specifier: ^4.0.0
         version: 4.2.0
       '@takazudo/zfb':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.41
-        version: 0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
       '@takazudo/zudo-doc':
-        specifier: ^0.2.4
-        version: 0.2.4(@takazudo/zfb-runtime@0.1.0-next.41(@takazudo/zfb@0.1.0-next.41))(@takazudo/zfb@0.1.0-next.41)(@takazudo/zudo-doc-history-server@0.2.4)(preact@10.29.2)(shiki@4.2.0)
+        specifier: ^0.2.9
+        version: 0.2.9(@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49))(@takazudo/zfb@0.1.0-next.49)(@takazudo/zudo-doc-history-server@0.2.9)(preact@10.29.2)(shiki@4.2.0)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^0.2.4
-        version: 0.2.4
+        specifier: ^0.2.9
+        version: 0.2.9
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -570,58 +570,58 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.41':
-    resolution: {integrity: sha512-0GgxEnFn2J7waYxyUR6Hvzll/5wvkt4JK9lIDa74iro4H3fP70XvkvZaoTLpBIK6JDMR0YObM36COC3riZfDDA==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49':
+    resolution: {integrity: sha512-1ilAvfQcTUHa4nmV0XU8zHPjIzfr0hUdJJACtklYYHkWVyemh1k9hoRUZm2MAKYVwye6BZV/p5x1zkxCYn3P2g==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.41':
-    resolution: {integrity: sha512-uwUVwc6k3FuP9Kzw8JChP7R7wDwCVS3UqEFFcTVLmpeHrDP2h0+48AwDlwzls88knDz621PozjSq/2ojxlhaPA==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
+    resolution: {integrity: sha512-pUDptGa4L4mxfn7vThzpYDjszkuhvfLHwDuBBvZ/qC1Uz32/nqJJOxl8ZdwkzpfzYGkna1I9OzUUnx9QBv2Qiw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.41':
-    resolution: {integrity: sha512-aswliW7P9bJu/YfaRmILMxFOmw8qiGOl/QboIjMcXzPuqCCtnLpYNZwxnVj4K4C8z90cDs9kCmJrunCCCfEvcQ==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
+    resolution: {integrity: sha512-iJrktID8Momn3CHBzMjU31F6NzlnV89QM/v/iMiZGnEtLote6HJcXDstm5xoghbX2i6RynCJ0CTiUNu4meEAKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.41':
-    resolution: {integrity: sha512-+9yHAnu8oNbYPlvratBLMrhGMn4x//4XB6vNXR0M0NYNq+AsKwOvpmJ4aNAxHq7Ty6OnMu5dH6eUN/KYUIUH4Q==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
+    resolution: {integrity: sha512-m0DsadTcMVAztEqnWhW21NYMGtE+78LRErYVi2eoLIrLD2VhwGeIl7dxx8qUBw2DS3Y/QiIkXC9WZbvhSQ68Mw==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.41':
-    resolution: {integrity: sha512-ykN9KFdSfzjhElMPFj26wVr/HAzn/0lfUHmXjVkciEt8B22JPz9RJT4gl02MwUKIrJDvDF4r5ZtxD3TF+r28Bw==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
+    resolution: {integrity: sha512-aQYxEYIufy5DL9/J8uuCGsZATmmvT28x/TWrft4YzkCToEgGSbQgCE6p7XGOTvJWsQpSGq8nVwHbIjHb7os0dg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.41':
-    resolution: {integrity: sha512-0/V4srUTz1r05GJgujFJHo2uu/ukVRAHE3k+akOaf6uuCv2gvs9fut1m8nlYX1jqvRdLk6xdQbQIt/m/AOCeAQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.49':
+    resolution: {integrity: sha512-5sg3EEOQbwe5FSP0dH/8eDNODlhJlWzc5sXGNSe9tnwy3EZeIV36zWy0nqhgEyjuaSnfgQPdkO1V/xX84IG/TQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.41
+      '@takazudo/zfb': 0.1.0-next.49
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.41':
-    resolution: {integrity: sha512-zBmwAAVCbN9lgNAswL2sAchBQddN2tDfglos96a9yWuJkzfyucqBnKm6TE6Bc8W86oq97+Y2cQUOqjtBDvIw3w==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
+    resolution: {integrity: sha512-GMucMsaD3e2WYs4q8zK844CvAq88NPJRm7BnO6+AEsVB/Mfec/wD2oBbp94Q7eDr6PoJCTEFXO0o44fvgT6zrg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.41':
-    resolution: {integrity: sha512-bu1MaXEyahQ3jbRK5f51bF7KQY14Kaiota1KKZIs0yoU+OkJ1DP+td5MZw94I4Y70Bs5kjktlpRYw82EDQyh7w==}
+  '@takazudo/zfb@0.1.0-next.49':
+    resolution: {integrity: sha512-IyZqXSjsS5mAleErx74LeNq/7ZvxJfBOqlUwl3Sz+0HcOAWj811Worevh+TZUiRo23MRgeoLFn83VJk185ftcg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zudo-doc-history-server@0.2.4':
-    resolution: {integrity: sha512-YNVJgdeGSRZ1Nko2XVhWR6XaiKn/xJhAO8w0iUK4VenevxdMYL5RtV3SxeQALtdXQ45FUyn3wOWtA5/+Rj0Deg==}
+  '@takazudo/zudo-doc-history-server@0.2.9':
+    resolution: {integrity: sha512-JF+fWItfOPNIdz6I1xOZS3nSLuvsimobOVbsqr8slWYj/lYq0EXkAmvFwIqI3ecx2pPa9/rJvqz23WgtVYbslQ==}
     hasBin: true
 
-  '@takazudo/zudo-doc@0.2.4':
-    resolution: {integrity: sha512-fA7mBs2+I8OxmhJgpNNlNlRKjLJ8975aKA0I/rGvMK2IjNvHOvg4rIk8qTSfoMD2UWYIY3XolyfpnQtGrLridQ==}
+  '@takazudo/zudo-doc@0.2.9':
+    resolution: {integrity: sha512-A/ZhWL4Ux2E+Ba1G5nqWz9YakUw+D+CBLPAV+xEv6mdRzeGSOhAkmfYoeRzJdLWWVW2gxM74Hazq6sEPrvRn3g==}
     peerDependencies:
-      '@takazudo/zdtp': ^0.2.0-next.2
-      '@takazudo/zfb': ^0.1.0-next.41
-      '@takazudo/zfb-runtime': ^0.1.0-next.41
-      '@takazudo/zudo-doc-history-server': ^0.2.4
+      '@takazudo/zdtp': ^0.2.3
+      '@takazudo/zfb': ^0.1.0-next.49
+      '@takazudo/zfb-runtime': ^0.1.0-next.49
+      '@takazudo/zudo-doc-history-server': ^0.2.9
       preact: ^10.29.1
       shiki: ^4.0.2
     peerDependenciesMeta:
@@ -1988,46 +1988,46 @@ snapshots:
       tailwindcss: 4.3.1
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.41': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.41':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.41':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.41':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.41':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)':
+  '@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.41
+      '@takazudo/zfb': 0.1.0-next.49
       hono: 4.12.25
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.41':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.41':
+  '@takazudo/zfb@0.1.0-next.49':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.41
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.41
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.41
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.41
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.41
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.49
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.49
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.49
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.49
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.49
 
-  '@takazudo/zudo-doc-history-server@0.2.4': {}
+  '@takazudo/zudo-doc-history-server@0.2.9': {}
 
-  '@takazudo/zudo-doc@0.2.4(@takazudo/zfb-runtime@0.1.0-next.41(@takazudo/zfb@0.1.0-next.41))(@takazudo/zfb@0.1.0-next.41)(@takazudo/zudo-doc-history-server@0.2.4)(preact@10.29.2)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.9(@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49))(@takazudo/zfb@0.1.0-next.49)(@takazudo/zudo-doc-history-server@0.2.9)(preact@10.29.2)(shiki@4.2.0)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.41
-      '@takazudo/zfb-runtime': 0.1.0-next.41(@takazudo/zfb@0.1.0-next.41)
+      '@takazudo/zfb': 0.1.0-next.49
+      '@takazudo/zfb-runtime': 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
       gray-matter: 4.0.3
       preact: 10.29.2
     optionalDependencies:
-      '@takazudo/zudo-doc-history-server': 0.2.4
+      '@takazudo/zudo-doc-history-server': 0.2.9
       shiki: 4.2.0
 
   '@tybys/wasm-util@0.10.2':

--- a/doc/zfb-shim.d.ts
+++ b/doc/zfb-shim.d.ts
@@ -1,167 +1,23 @@
 // Local type shim for the bare `zfb/config` specifier.
 //
-// `@takazudo/zfb` is consumed as a published npm package (version pinned
-// in the root `package.json`). The package exposes its real config types
-// under the *scoped* subpath `@takazudo/zfb/config` → `dist/config.d.ts`.
-// But `zfb.config.ts` imports from the *bare* specifier `zfb/config`,
-// which zfb's build tool aliases to a runtime-only stub at parse time
-// (`zfb-config-stub.mjs` — `defineConfig` is identity, carrying no types).
-// No real file backs `zfb/config` in `node_modules`, so this ambient
-// declaration is what supplies the `ZfbConfig` type to `zfb.config.ts`.
+// `@takazudo/zfb` is consumed as a published npm package (version pinned in
+// `package.json`). It exposes its real config types AND `defineConfig` under
+// the *scoped* subpath `@takazudo/zfb/config` → `dist/config.d.ts`. But
+// `zfb.config.ts` imports from the *bare* specifier `zfb/config`, which zfb's
+// build tool aliases to a runtime-only stub at parse time (`zfb-config-stub.mjs`
+// — `defineConfig` is identity, carrying no types). No real file backs the bare
+// `zfb/config` in `node_modules`, so this ambient declaration is what supplies
+// the `defineConfig` + `ZfbConfig` types to `zfb.config.ts`.
 //
-// IMPORTANT — this block is the source of truth for the type `zfb check`
-// (plain `tsc --noEmit`) binds against the config. An ambient `declare
-// module` wins over node resolution AND over tsconfig `paths`, so it must
-// be kept in sync BY HAND with the published `@takazudo/zfb/config`
-// (`dist/config.d.ts`). When it lags the engine, valid config fields fail
-// `pnpm check` with TS2353 (see Takazudo/zudo-front-builder#678 +
-// zudolab/zudo-doc#1834 — `bundle` was missing here, blocking next.22's
-// `bundle.exclude`).
-
+// Per zfb next.48, instead of hand-maintaining a parallel `ZfbConfig`
+// declaration here (which drifted and failed `pnpm check` with TS2353 whenever
+// it lagged the engine — e.g. `bundle` then `codeHighlight.themeLight/themeDark`
+// were missing; see Takazudo/zudo-front-builder#678 + zudolab/zudo-doc#1834), we
+// re-export the published `@takazudo/zfb/config` surface from inside the
+// bare-module declaration. This must stay INSIDE `declare module "zfb/config"`:
+// the bare specifier has no backing file, so a top-level `export *` would not
+// attach to it. Re-exporting keeps the bare-specifier types in lockstep with the
+// installed engine automatically — no more hand reconciliation on bumps.
 declare module "zfb/config" {
-  /** JSX framework runtime. */
-  export type Framework = "preact" | "react";
-
-  /** A content collection registered with the zfb engine. */
-  export interface CollectionDef {
-    /** Identifier used at the call site (e.g. `"docs"`). */
-    name: string;
-    /** Directory (relative to the project root) holding the entries. */
-    path: string;
-    /**
-     * Optional schema. Reserved for v1.1 — accepted but not enforced
-     * today. Authored as zod and converted to JSON Schema via
-     * `z.toJSONSchema()` at the boundary.
-     */
-    schema?: Record<string, unknown>;
-  }
-
-  /** Tailwind options; absent = defaults. */
-  export interface TailwindConfig {
-    enabled?: boolean;
-  }
-
-  /** User-supplied plugin configuration entry. */
-  export interface PluginConfig {
-    name: string;
-    options?: Record<string, unknown>;
-  }
-
-  /**
-   * Bundler options. Mirrors `BundleConfig` in crates/zfb/src/config.rs
-   * and the published `@takazudo/zfb/config` (`dist/config.d.ts`). Added
-   * in next.22 (`bundle.exclude`, #664) and extended in next.23
-   * (`mainFields` / `external`, #676).
-   */
-  export interface BundleConfig {
-    /**
-     * Project-relative, gitignore-style globs for source files the bundler
-     * must NOT pull into the esbuild graph (e.g. test fixtures or
-     * `*.stories.tsx`). Matched files are skipped from the shadow-tree walk
-     * and dropped from any eager `import.meta.glob(...)` expansion.
-     */
-    exclude?: string[];
-    /**
-     * Explicit esbuild `main-fields` for the `--platform=neutral` page/SSR
-     * pass (empty by default under `neutral`), letting CJS-`main`-only deps
-     * resolve. Mirrors `BundleConfig::main_fields`.
-     */
-    mainFields?: string[];
-    /**
-     * Bare specifiers to mark external in the `--platform=neutral` pass so
-     * esbuild leaves them unbundled. Mirrors `BundleConfig::external`.
-     */
-    external?: string[];
-  }
-
-  /** Mirrors the Rust `Config` struct one-for-one. */
-  export interface ZfbConfig {
-    outDir?: string;
-    publicDir?: string;
-    host?: string;
-    port?: number;
-    framework?: Framework;
-    collections?: CollectionDef[];
-    tailwind?: TailwindConfig;
-    /**
-     * Bundler options. `bundle.exclude` keeps project-relative globs out of
-     * the esbuild graph — used here to skip `packages/md-plugins/__fixtures__/**`
-     * so the MDX link resolver no longer walks the test fixtures (silences
-     * ~15 pre-existing broken-link warnings). Mirrors `Config::bundle`.
-     */
-    bundle?: BundleConfig;
-    plugins?: PluginConfig[];
-    adapter?: string;
-    /**
-     * Strip `.md` / `.mdx` from in-page `<a href>` paths and append a
-     * trailing `/` so author-written `[label](other.mdx)` references
-     * resolve to the rendered route URL. Mirrors Config::strip_md_ext
-     * in crates/zfb/src/config.rs (zudolab/zfb#131).
-     */
-    stripMdExt?: boolean;
-    /**
-     * Site base path. Prefixed onto stable HTML asset URLs (CSS / JS
-     * `<link>` and `<script>` tags). Normalised to start AND end with
-     * `/`; `undefined` / `""` / `"/"` all behave identically (no
-     * prefix). Mirrors Config::base in crates/zfb/src/config.rs
-     * (Takazudo/zudo-front-builder#154).
-     */
-    base?: string;
-    /**
-     * Configures the syntect-based syntax highlighter shipped with zfb.
-     * Mirrors `code_highlight` in crates/zfb/src/config.rs (Takazudo/zudo-front-builder#188 / sub #194; landed in commit 339e30f).
-     * When omitted, the engine falls back to the hardcoded default theme `base16-ocean.dark`.
-     */
-    codeHighlight?: {
-      theme?: string;
-      themesDir?: string;
-    };
-    /**
-     * Markdown link resolver (port of `remarkResolveMarkdownLinks`).
-     * Mirrors `Config::resolve_markdown_links` in crates/zfb/src/config.rs
-     * (Takazudo/zudo-front-builder PR #234 / zudolab/zudo-doc#1577).
-     * When `enabled: true`, the build appends `ResolveLinksPlugin` to the
-     * mdast pipeline so author-written `[label](./other.mdx)` links are
-     * rewritten to the corresponding rendered route URL — bypassing the
-     * file→directory transformation that breaks relative paths in dist
-     * HTML when `foo.mdx` becomes `foo/index.html`.
-     */
-    resolveMarkdownLinks?: {
-      enabled?: boolean;
-      docsDir?: string;
-      dirs?: Array<{ dir: string; routePrefix: string }>;
-      onBrokenLinks?: "warn" | "error" | "ignore";
-    };
-    /**
-     * Whether the basePath rewriter should append a trailing `/` to
-     * extensionless absolute hrefs. Mirrors `Config::trailing_slash` in
-     * crates/zfb/src/config.rs (Takazudo/zudo-front-builder PR #234 /
-     * zudolab/zudo-doc#1579). Off by default — preserves byte-for-byte
-     * parity with the pre-`trailingSlash` build for projects that
-     * haven't opted in.
-     */
-    trailingSlash?: boolean;
-    /**
-     * Markdown / MDX pipeline options. Mirrors `Config::markdown` →
-     * `MarkdownConfig` in crates/zfb/src/config.rs. zfb next.12 moved the
-     * former-Core features under `markdown.features` and next.13 ships the
-     * rest as opt-in; zudo-doc uses `markdown.features` to opt back into the
-     * former-Core four plus the additional opt-in features (#1804). Each
-     * `features` value is per-feature: `true` for boolean-shorthand features,
-     * or an options object for object-typed features.
-     */
-    markdown?: {
-      gfm?: boolean | Record<string, boolean>;
-      toc?: Record<string, unknown>;
-      externalLinks?: Record<string, unknown>;
-      cjkFriendly?: boolean;
-      features?: Record<string, boolean | Record<string, unknown>>;
-    };
-  }
-
-  /**
-   * Identity helper: returns the supplied config as-is, but typed
-   * against `ZfbConfig`. Use as the default export of `zfb.config.ts`.
-   */
-  export function defineConfig(config: ZfbConfig): ZfbConfig;
+  export * from "@takazudo/zfb/config";
 }

--- a/doc/zfb.config.ts
+++ b/doc/zfb.config.ts
@@ -95,6 +95,16 @@ export default defineConfig({
   // CLAUDE.md and the Tauri dev wrappers assume 4321.
   port: 4321,
   tailwind: { enabled: true },
+  // Dual-theme syntect highlighting (zfb next.47 / zudo-doc 0.2.8). Both names
+  // are SYNTECT built-ins (NOT Shiki names); setting the pair makes the engine
+  // color tokens with `--shiki-light`/`--shiki-dark` CSS custom props instead of
+  // a single inline `color:`, which `src/styles/global.css` resolves via
+  // `light-dark()`. Without this the default single `base16-ocean.dark` theme
+  // renders near-invisible code on the light site theme.
+  codeHighlight: {
+    themeLight: "base16-ocean.light",
+    themeDark: "base16-ocean.dark",
+  },
   collections,
   stripMdExt: true,
   resolveMarkdownLinks: {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-pd/issues/61
    - https://github.com/Takazudo/zudo-pd/issues/60 (epic)

---

## Summary

Bumps the `/doc/` site's upstream deps to latest and reconciles the 0.2.4-era
scaffold/shim/config to the new engine surface (zudo-doc ships no scaffold-sync
command, so this is a manual reconcile).

| Package | From | To |
|---|---|---|
| `@takazudo/zfb` / `zfb-runtime` / `zfb-adapter-cloudflare` | 0.1.0-next.41 | **0.1.0-next.49** |
| `@takazudo/zudo-doc` / `zudo-doc-history-server` | 0.2.4 | **0.2.9** |

## Changes

- **`zfb-shim.d.ts`** — replaced the 166-line hand-maintained `declare module "zfb/config"`
  block with the upstream **next.48 re-export pattern**
  (`declare module "zfb/config" { export * from "@takazudo/zfb/config"; }`). Drift-proof:
  the bare-specifier types now track the installed engine automatically, ending the recurring
  TS2353 reconcile chore. (Stays inside the ambient module — the bare `zfb/config` has no
  backing file in `node_modules`.)
- **`zfb.config.ts`** — enabled **dual-theme syntect highlighting**
  (`codeHighlight.themeLight: "base16-ocean.light"` / `themeDark: "base16-ocean.dark"`). The
  `light-dark()` plumbing in `global.css` was already present but inert; code now emits
  `--shiki-light`/`--shiki-dark` token + background custom properties, fixing the
  near-invisible code that the single `base16-ocean.dark` default produced on the light theme.
- **`package.json` / `pnpm-lock.yaml`** — version bumps + lockfile regen (pnpm 11.5.2, the
  CI-pinned version). pnpm 11.5.2's default release-age `minimumReleaseAgeExclude` churn
  (today-published packages) intentionally **not** committed — CI's `--frozen-lockfile`
  bypasses that gate (verified).

## Test Plan

- `pnpm check` ✓ `pnpm build` ✓ (63 pages, `dist/_worker.js`) `pnpm check:html` ✓
- Render-verified (screenshots): code highlighting readable in **both** light & dark themes;
  mermaid renders to SVG; sidebar/TOC/tables/header clean; **zero** console/network errors;
  no z-index/stacking regressions.
- Independent Opus code review: sound, no CI/production-breaking issues.

## Out of scope (raised separately)

- Pre-existing, **not** introduced here (confirmed on the live production site): admonitions
  render as literal `:::tip Title` text (Docusaurus space-form vs remark-directive brackets)
  → #63.
- Upstream zfb enhancement: `imageDimensions` warns on every SVG with no opt-out →
  Takazudo/zudo-front-builder#1083.