### PR TITLE
fix(doc): commit minimumReleaseAgeExclude so CI accepts the fresh zfb/zudo-doc bump

### DIFF
--- a/doc/pnpm-workspace.yaml
+++ b/doc/pnpm-workspace.yaml
@@ -6,3 +6,19 @@ allowBuilds:
   esbuild: true
   sharp: true
   workerd: true
+# pnpm 11.5.2's default minimumReleaseAge gate (~24h cooldown) rejects packages
+# published within the cutoff, and CI's `pnpm install --frozen-lockfile` enforces
+# it (ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION). These first-party @takazudo packages
+# were published the same day as this bump, so each adopted version must be
+# explicitly approved here or CI fails. pnpm regenerates this list on the next bump.
+minimumReleaseAgeExclude:
+  - '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49'
+  - '@takazudo/zfb-darwin-arm64@0.1.0-next.49'
+  - '@takazudo/zfb-darwin-x64@0.1.0-next.49'
+  - '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49'
+  - '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49'
+  - '@takazudo/zfb-runtime@0.1.0-next.49'
+  - '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49'
+  - '@takazudo/zfb@0.1.0-next.49'
+  - '@takazudo/zudo-doc-history-server@0.2.9'
+  - '@takazudo/zudo-doc@0.2.9'


### PR DESCRIPTION
Hotfix for `main` going red after #62 merged.

## Problem

The production deploy on `main` (commit 40a898b) failed at `pnpm install --frozen-lockfile`:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 10 lockfile entries failed verification:
  @takazudo/zfb@0.1.0-next.49 was published at 2026-06-16T07:26:57Z, within the minimumReleaseAge cutoff
  ... (all 10 freshly-published zfb/zudo-doc packages)
```

pnpm 11.5.2's default `minimumReleaseAge` gate (~24h cooldown) rejects packages published within the cutoff, and `--frozen-lockfile` enforces the supply-chain policy. The zfb next.49 / zudo-doc 0.2.9 packages were published the same day as the bump, so CI rejected the lockfile.

## Fix

Commit the `minimumReleaseAgeExclude` list (the entries pnpm auto-generated during the bump install) to `doc/pnpm-workspace.yaml`. This is the intended mechanism for explicitly approving fresh first-party `@takazudo/*` versions. pnpm regenerates the list on the next bump.

## Verification

Faithful CI replication — `rm -rf doc/node_modules && pnpm install --frozen-lockfile` — now **passes** the supply-chain policy check (previously it was short-circuited locally by populated node_modules, which is why #62's pre-merge check gave a false green). `pnpm check` still green.