### PR TITLE
fix(doc): render admonitions as JSX (zfb next.49 directive engine is broken)

### DIFF
--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -63,27 +63,40 @@ When the user provides a local docs URL like `http://localhost:4321/docs/...`:
 
 ## Authoring Rules (Markdown / MDX)
 
-1. **File extension**: use `.md` when the page has no JSX; use `.mdx` only when
-   it uses JSX components (`<Details>`, `<CategoryNav>`, etc.). Native `:::`
-   admonitions do NOT require `.mdx`.
+1. **File extension**: use `.md` by default; use `.mdx` when a page uses
+   interactive/nav JSX components (`<CategoryNav>`, `<PresetGenerator>`, etc.).
+   The admonition tags (`<Note>`/`<Tip>`/… and `<Details>`) and inline
+   `<MathBlock>` are the exception — they render in plain `.md` (the engine
+   compiles every page through the MDX pipeline), so a page that uses **only**
+   those does NOT need a `.mdx` rename. Renaming to `.mdx` also forces every
+   inbound internal link to update its extension (see rule 9), so prefer `.md`.
 2. **Frontmatter**: `title:` is **required** (it renders as the page h1).
    `sidebar_position:` controls sidebar order (lower = higher). Optional
    `sidebar_label:`, `description:`.
 3. **No `# H1` in the body** — start headings at `##` (the frontmatter `title`
    is the h1).
-4. **Admonitions** — use the native directive syntax (globally available, no
-   import):
-   ```mdx
-   :::note
+4. **Admonitions** — author as **JSX tags** (globally available, no import).
+   Works in plain `.md` too (no `.mdx` rename needed):
+   ```md
+   <Note>
    General information.
-   :::
+   </Note>
 
-   :::tip[Custom Title]
-   A helpful suggestion.
-   :::
+   <Tip title="Custom Title">
+   A helpful suggestion. Body is normal markdown — **bold**, lists, links,
+   code, and multiple paragraphs all render.
+   </Tip>
    ```
-   Available: `:::note`, `:::tip`, `:::info`, `:::warning`, `:::danger`
-   (and `:::caution`). Five core styles.
+   Available: `<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>`, `<Caution>`.
+   The optional `title="…"` attribute is the callout heading (defaults to the
+   capitalized variant name). Put the body on its own lines between the tags.
+
+   > **Do NOT use the `:::name` directive form.** The zfb next.49 engine does
+   > not transform container directives — `:::tip[Title]` leaks through as
+   > literal `:::tip[Title]` text in the rendered page. Upstream bug:
+   > Takazudo/zudo-front-builder#1085. The `directives` map in `zfb.config.ts`
+   > is kept (commented) so `:::` authoring can be restored in one revert once
+   > the engine is fixed. Until then, JSX is the only form that renders.
 5. **Collapsible blocks** — use `<Details title="...">...</Details>` (global,
    no import). Makes the file `.mdx`.
 6. **Category landing pages** — use `<CategoryNav category="<section>" />` in a

--- a/doc/src/content/docs/components/ch224d.md
+++ b/doc/src/content/docs/components/ch224d.md
@@ -8,7 +8,8 @@ USB Power Delivery protocol negotiation IC for obtaining 15V/3A power from USB-C
 - [View on JLCPCB: C3975094](https://jlcpcb.com/partdetail/C3975094)
 - [Download Datasheet (PDF)](/datasheets/CH224D-datasheet.pdf)
 
-:::danger Deprecated - v1.0 Only
+<Danger title="Deprecated - v1.0 Only">
+
 **CH224D is used in v1.0 only and has been replaced by [STUSB4500](./stusb4500.md) in v1.1.**
 
 **Reason for replacement:** CH224D has poor charger compatibility (~33%). Only 2 out of 6 tested USB-PD chargers worked with CH224D. STUSB4500 is USB-IF certified with ~95%+ expected compatibility.
@@ -22,9 +23,11 @@ USB Power Delivery protocol negotiation IC for obtaining 15V/3A power from USB-C
 | CIO NovaPort SLIM 45W | ❌ Fails      | ✅ Expected      |
 
 See [GitHub Issue #33](https://github.com/Takazudo/zudo-pd/issues/33) for details.
-:::
 
-:::warning Critical Understanding - VBUS is Input AND Output!
+</Danger>
+
+<Warning title="Critical Understanding - VBUS is Input AND Output!">
+
 **CH224D does NOT have a separate VOUT pin!**
 
 - **Pin 2 (VBUS)** is BOTH input (initially 5V) AND output (15V after PD negotiation)
@@ -39,7 +42,8 @@ See [GitHub Issue #33](https://github.com/Takazudo/zudo-pd/issues/33) for detail
 - **CC pull-downs required**: 5.1kΩ resistors on CC1 and CC2 to GND (identifies device as USB-PD sink)
 
 See datasheet page 4 (Section 6.1) for reference schematic.
-:::
+
+</Warning>
 
 ![CH224D QFN-20 Package](/footprints/QFN-20_L3.0-W3.0-P0.40-BL-EP1.7.svg)
 

--- a/doc/src/content/docs/components/esda25l.md
+++ b/doc/src/content/docs/components/esda25l.md
@@ -3,11 +3,13 @@ title: ESDA25L - TVS Diode (Legacy)
 sidebar_position: 6
 ---
 
-:::warning Not Used in Current Design
+<Warning title="Not Used in Current Design">
+
 ESDA25L has been **replaced by [USBLC6-2SC6](./usblc6-2sc6.md)** in v1.1 design.
 
 **Reason**: ESDA25L's clamping voltage (~44V) is too high for CC line protection. USBLC6-2SC6 clamps at ~17V and includes VBUS protection.
-:::
+
+</Warning>
 
 TVS diode for high-voltage ESD and overvoltage protection.
 

--- a/doc/src/content/docs/components/faston-terminal.md
+++ b/doc/src/content/docs/components/faston-terminal.md
@@ -14,9 +14,11 @@ Heavy-duty FASTON 250 series PCB tab terminal for busboard power connection, sup
 
 The FASTON 250 terminal (TE 63951-1) is an industrial-grade quick-connect PCB tab terminal from TE Connectivity. It provides a robust power output interface for connecting the USB-PD power supply to a Eurorack busboard using standard FASTON 250 (6.35mm / 0.250") receptacle connectors.
 
-:::note v0.4.0 part change
+<Note title="v0.4.0 part change">
+
 The original `1217754-1` (LCSC C305825) went out of stock at JLCPCB. v0.4.0 switched to **`63951-1` (LCSC C591344)** — the _same physical tab_, supplied on strip/reel instead of loose piece (TE catalog 82004 lists both on the same row). Identical footprint: 2 right-angle legs at 5.08 mm pitch, 1.4 mm holes, 6.35 mm blade, 8.89 mm height — so the PCB land pattern is unchanged.
-:::
+
+</Note>
 
 This design uses **4 terminals** for the three power rails plus ground return:
 

--- a/doc/src/content/docs/components/stusb4500.md
+++ b/doc/src/content/docs/components/stusb4500.md
@@ -8,7 +8,8 @@ USB-IF certified USB Power Delivery sink controller for reliable 15V/3A power ne
 - [View on JLCPCB: C2678061](https://jlcpcb.com/partdetail/C2678061)
 - [Download Datasheet (PDF)](https://www.st.com/resource/en/datasheet/stusb4500.pdf)
 
-:::tip Why STUSB4500 over CH224D?
+<Tip title="Why STUSB4500 over CH224D?">
+
 **STUSB4500 is USB-IF certified** with significantly better charger compatibility:
 
 | Feature          | CH224D   | STUSB4500       |
@@ -22,7 +23,8 @@ USB-IF certified USB Power Delivery sink controller for reliable 15V/3A power ne
 | Configuration    | Resistor | **NVM + I2C**   |
 
 CH224D failed with most modern GaN chargers. STUSB4500 is the recommended replacement for v1.1.
-:::
+
+</Tip>
 
 ## Overview
 
@@ -198,7 +200,8 @@ USB-C CC2 (B5) ───→ Pin 3 (I/O2) ───→ Pin 4 (I/O2) ───→ 
 
 - `VBUS_IN` → `R14 (470Ω)` → `VBUS_VS_DISCH (pin 18)`
 
-:::info How DISCH Works
+<Info title="How DISCH Works">
+
 When USB-C cable is disconnected, STUSB4500 opens an internal path from DISCH pin to GND. This allows capacitor charge to escape:
 
 ```
@@ -206,7 +209,8 @@ VBUS_OUT (15V) → R13 (470Ω) → DISCH → GND (inside STUSB4500)
 ```
 
 The stored energy drains as heat through R13 (~0.5W briefly). This is required by USB-C spec to bring VBUS to safe level (&lt;0.8V) quickly, preventing hot-plug hazards.
-:::
+
+</Info>
 
 **Configuration:**
 
@@ -235,12 +239,14 @@ The stored energy drains as heat through R13 (~0.5W briefly). This is required b
 | R13       | 470Ω  | ±1%       | 0603    | VBUS discharge (31mA @ 15V)       |
 | R14       | 470Ω  | ±1%       | 0603    | VBUS_VS_DISCH series resistor     |
 
-:::info R12 Value Selection
+<Info title="R12 Value Selection">
+
 R12 was changed from 33kΩ to 56kΩ to provide adequate Vgs margin for Q1:
 
 - With R12=56kΩ: Vgs = -15V × 100k/(100k+56k) = **-9.6V** (20% margin from ±12V max)
 - With R12=33kΩ: Vgs = -11.3V (only 6% margin - too close to limit)
-  :::
+
+</Info>
 
 ### Load Switch MOSFET
 
@@ -254,13 +260,15 @@ R12 was changed from 33kΩ to 56kΩ to provide adequate Vgs margin for Q1:
 | --------- | ----------- | --------------- | --- | -------- | ----------- | -------- | ----- |
 | D4        | USBLC6-2SC6 | TVS Diode Array | 5V  | 2 + VBUS | 3.5pF       | SOT-23-6 | C7519 |
 
-:::tip Why USBLC6-2SC6?
+<Tip title="Why USBLC6-2SC6?">
+
 
 - **Low clamping voltage** (~17V) - better protection for CC lines operating at ~1.7V
 - **Includes VBUS protection** - pin 5 can connect to VBUS_IN for additional transient protection
 - **USB-specific design** - optimized for USB-C applications
 - **Low capacitance** (3.5pF) - doesn't affect CC line signaling
-  :::
+
+</Tip>
 
 ## NVM Configuration
 

--- a/doc/src/content/docs/components/usblc6-2sc6.md
+++ b/doc/src/content/docs/components/usblc6-2sc6.md
@@ -12,7 +12,8 @@ TVS diode array for USB Type-C CC line and VBUS ESD protection. Replaces ESDA25L
 
 The USBLC6-2SC6 is a 6-pin TVS diode array specifically designed for USB ESD protection. It provides 2 bidirectional channels for data/CC lines plus a VBUS protection channel, making it ideal for USB Type-C applications.
 
-:::tip Why USBLC6-2SC6 over ESDA25L?
+<Tip title="Why USBLC6-2SC6 over ESDA25L?">
+
 | Feature | ESDA25L | USBLC6-2SC6 |
 |---------|---------|-------------|
 | Clamping Voltage | ~44V | **~17V** |
@@ -22,7 +23,8 @@ The USBLC6-2SC6 is a 6-pin TVS diode array specifically designed for USB ESD pro
 | Design Target | High-voltage lines | **USB signals** |
 
 USBLC6-2SC6 has lower clamping voltage, providing better protection for CC lines operating at ~1.7V.
-:::
+
+</Tip>
 
 ## Key Specifications
 

--- a/doc/src/content/docs/inbox/nvm-programming.md
+++ b/doc/src/content/docs/inbox/nvm-programming.md
@@ -36,9 +36,11 @@ Additional settings:
 - `SNK_PDO_NUMB` = **2** (only PDO1 + PDO2; PDO3 never advertised → 20V never requested)
 - `POWER_ONLY_ABOVE_5V` = **enabled** (VBUS_EN_SNK only activates after 15V negotiation succeeds)
 
-:::tip Why SNK_PDO_NUMB = 2 instead of 3?
+<Tip title="Why SNK_PDO_NUMB = 2 instead of 3?">
+
 The STUSB4500's priority logic between PDOs is documented ambiguously across ST sources (some say PDO3 has highest priority by number, some say highest-power wins). The only way to *guarantee* 20V is never requested is to not advertise it at all. The design needs 15V, not 20V, and a charger lacking 15V wouldn't power this device usefully anyway.
-:::
+
+</Tip>
 
 ## Hardware Required
 
@@ -82,9 +84,11 @@ The pogo clip's dupont wires connect to the Nucleo's D14, D15, and GND pins. The
 
 The Nucleo I2C operates at 3.3V, compatible with STUSB4500's VREG_2V7 (2.7V) via open-drain I2C bus. No level shifter needed.
 
-:::info Why not STEVAL-ISC005V1?
+<Info title="Why not STEVAL-ISC005V1?">
+
 The STEVAL-ISC005V1 (~7,000 JPY on DigiKey Japan) has its own STUSB4500 and USB-C connector. It's designed for evaluating the IC standalone. Since we have our own PCB with the STUSB4500 already soldered, we only need the Nucleo as an I2C bridge. The GUI documentation confirms it works with "evaluation board, or custom board containing STUSB device."
-:::
+
+</Info>
 
 ### Option B: Arduino / MCU via I2C (Alternative)
 
@@ -108,9 +112,11 @@ The v1 schematic has SCL (pin 7) and SDA (pin 8) as NC (not connected). These mu
 | R15 | Resistor | [C23162](https://jlcpcb.com/partdetail/C23162) | 4.7kohm | 0603 | I2C SCL pull-up |
 | R16 | Resistor | [C23162](https://jlcpcb.com/partdetail/C23162) | 4.7kohm | 0603 | I2C SDA pull-up |
 
-:::info J2 Pogo Pads - No Assembly Cost
+<Info title="J2 Pogo Pads - No Assembly Cost">
+
 J2 is not a physical component - it is bare copper SMD pads on the PCB edge. No JLCPCB component or assembly fee is needed. The pogo pin clip (external tool) clamps onto these pads during programming. This saves ~$7 compared to a THT pin header (Extended part fee + hand-soldering fee).
-:::
+
+</Info>
 
 ### KiCad Symbol and Footprint
 
@@ -212,13 +218,15 @@ Pull-ups connect to VREG_2V7 (2.7V) since this is the I2C bus voltage for the ST
 8. **Unplug and replug USB** — the Nucleo needs to re-enumerate with the new firmware
 9. Verify in Windows Device Manager: **Ports (COM & LPT)** should show "STMicroelectronics STLink Virtual COM Port (COMx)". If no COM port appears, install the [ST-Link VCP driver](https://www.st.com/en/development-tools/stsw-link009.html).
 
-:::warning HID vs UART .bin choice (critical)
+<Warning title="HID vs UART .bin choice (critical)">
+
 The HID variant requires a **separate USB connection to the STM32F072's native USB pins (PA11/PA12)**, which on the NUCLEO-F072RB are only broken out to header pins — not wired to CN1. The HID firmware is intended for use with the **STEVAL-ISC005V1** daughter board, which provides this second USB connection.
 
 For our setup (bare NUCLEO-F072RB, no STEVAL daughter board), only the UART firmware works because it communicates through the **ST-Link's built-in Virtual COM Port (VCP)** over the same CN1 USB cable.
 
 Symptom of wrong choice: GUI shows "STM32-Nucleo-board not Detected" even after flash + replug. Only "ST-Link debug" appears in Device Manager. Fix: re-flash with the UART .bin.
-:::
+
+</Warning>
 
 Sources:
 - [STSW-STUSB002 quick start guide (PDF)](https://www.st.com/resource/en/product_presentation/stswstusb002_quick_start_v3_2.pdf) — explicit UART vs HID guidance
@@ -266,15 +274,18 @@ If J3 pad 4 is 0 V with a USB-C-to-USB-C charger, try a known-good **USB-A-to-US
 source. USB-A-to-C supplies 5 V directly through the cable, which separates "board cannot
 request VBUS over CC" from "VBUS trace or chip supply is physically broken."
 
-:::warning Charger choice for initial programming
+<Warning title="Charger choice for initial programming">
+
 The factory NVM in a fresh STUSB4500 advertises PDO3 = 20V/1.0A with **highest priority**. A full PD charger that supports 20V will negotiate 20V on first plug-in, sending **20V through your DC-DC converters designed for 15V** — likely damaging them.
 
 **Use a 5V-only USB-C charger** (any phone charger) or a PD charger that maxes out at 9V/15V (no 20V profile) for the initial programming session. The chip's VDD only needs 5V to communicate via I2C.
 
 After NVM is written with `SNK_PDO_NUMB = 2` (no 20V advertised), you can safely switch to your real PD charger.
-:::
 
-:::tip Detection sequence
+</Warning>
+
+<Tip title="Detection sequence">
+
 The GUI launch normally shows two dialogs in sequence:
 
 1. **"STM32-Nucleo-board not Detected"** — appears if no Nucleo is connected, GUI starts in "File Edition mode"
@@ -287,7 +298,8 @@ After clipping the pogo onto the powered board, **close and reopen the GUI** —
 ```
 
 Once detected, the "Read device NVM" and "Write device NVM" buttons appear in the top-right.
-:::
+
+</Tip>
 
 ### Step 3: Program NVM
 

--- a/doc/src/content/docs/inbox/v3-bringup-test-procedure.md
+++ b/doc/src/content/docs/inbox/v3-bringup-test-procedure.md
@@ -8,23 +8,27 @@ next: if a stage fails its pass criteria, **stop and debug before powering furth
 downstream rails have never run on real hardware (v1 and v2 both died at the USB-PD front
 end), so v3 is the first board where the DC-DC + LDO chain is exercised at all.
 
-:::danger The two independent gambles
+<Danger title="The two independent gambles">
+
 1. **Does the v3 CC-termination fix work?** (external Rd + CC1DB/CC2DB isolation — the v2 killer)
 2. **Does the never-before-tested power chain behave?** (DC-DC + LDO + protection)
 
 These are separable, and you should test them separately. The cleanest way to de-risk
 gamble #2 without depending on #1 is to **inject 15 V from a bench supply at TP1 (VBUS_OUT)**,
 bypassing USB-PD entirely — see Stage 4.
-:::
 
-:::warning Before anything: the 20 V hazard
+</Danger>
+
+<Warning title="Before anything: the 20 V hazard">
+
 A **fresh, un-programmed** STUSB4500 advertises **20 V at highest priority**. On a
 20 V-capable PD charger it will negotiate 20 V within ~tens of ms of plug-in and push 20 V
 into a 15 V-rated DC-DC stage. **Never plug an un-programmed board into a full PD charger.**
 Use a current-limited bench supply, a 5 V-only charger, or a no-20V (max 9/15 V) source until
 the NVM is written. (USB-C always starts at 5 V vSafe5V, so the instant of plug-in is safe;
 the danger is the negotiation a few ms later.)
-:::
+
+</Warning>
 
 ## Tools & materials
 
@@ -98,9 +102,11 @@ The board will not negotiate 15 V until the NVM is reprogrammed. Full procedure:
 - GUI Dashboard must show **"Sink attached"**, not "No device attached." (The latter = a
   CC-termination hardware fault — go back to Stage 0.5 check #4.)
 
-:::caution NVM is rated ~1000 write cycles
+<Caution title="NVM is rated ~1000 write cycles">
+
 Program once. Don't loop writes.
-:::
+
+</Caution>
 
 **Pass**: NVM read-back confirms the 3 settings, Dashboard shows "Sink attached." → Stage 2.
 
@@ -123,12 +129,14 @@ settle = a short; kill power immediately.
 | VREG_2V7 (J3 pad 3) | **2.6–2.8 V** | Chip is alive and configured ("is the chip awake?") |
 | Idle current | settles to a low steady value | No short |
 
-:::warning Bench supply at VBUS_IN does **not** power the downstream rails
+<Warning title="Bench supply at VBUS_IN does **not** power the downstream rails">
+
 VBUS_OUT is gated by Q1 (AO3401A load switch), and Q1 only turns on when the chip asserts
 **VBUS_EN_SNK** after a valid PD contract. Injecting at VBUS_IN with no CC handshake leaves
 Q1 **off**, so the DC-DC chain stays dark. That's expected. To test the power chain
 independently, inject at **VBUS_OUT / TP1** instead — see Stage 4.
-:::
+
+</Warning>
 
 **Pass**: VREG_2V7 ≈ 2.7 V, current settles. → Stage 3.
 
@@ -153,11 +161,13 @@ Now the moment v2 failed at. **First, the acceptance test that proves the v3 Rd 
 
 **Diagnostic**: if VBUS_IN = 15 V but VBUS_OUT/TP1 = 0 V → VBUS_EN_SNK / Q1 gate path issue.
 
-:::tip If PD still fails on v3
+<Tip title="If PD still fails on v3">
+
 Lift **R19** (or R20) to isolate the chip's CC1DB/CC2DB pin from GND — this is exactly why
 0 Ω jumpers (not hard ties) were used. Last resort: hot-air U1 and meter the empty pad
 (OPEN = the short is inside the chip, as in v2).
-:::
+
+</Tip>
 
 **Pass**: TP1 = 15.0 V (not 20), PD_OK asserted. → Stage 4.
 
@@ -165,7 +175,8 @@ Lift **R19** (or R20) to isolate the chip's CC1DB/CC2DB pin from GND — this is
 
 ## Stage 4 — DC-DC intermediate rails
 
-:::tip Decouple from USB-PD — inject 15 V at TP1 (with one pre-check)
+<Tip title="Decouple from USB-PD — inject 15 V at TP1 (with one pre-check)">
+
 To test the power chain **without depending on PD**, you can feed a bench supply into
 **TP1 (+) / TP2 (GND)** at **15.0 V, limit ~200–300 mA**. TP1's net is the **`VBUS_OUT`**
 global label (downstream of the Q1 load switch), so this bypasses the USB-PD front end and
@@ -185,7 +196,8 @@ drives the DC-DC + LDO chain directly. `VBUS_OUT` enters the DC-DC sheet as the
 Note: there is **no input fuse** on the VBUS path (the SMD fuses are all on the output rails).
 If you inject and a converter stays dark, confirm 15 V actually reaches *that* converter's VIN
 before suspecting the converter itself.
-:::
+
+</Tip>
 
 Probe each intermediate at its test point:
 
@@ -195,7 +207,8 @@ Probe each intermediate at its test point:
 | **TP4** | +7.5 V | U3 LM2596 (R3=5.1k/R4=1k → 7.50 V) | +7.5 V | 7.3–7.7 V |
 | **TP5** | −13.5 V | U4 LM2596 **inverting buck-boost** (+15 V → −13.5 V *directly*) | −13.5 V | −13.2 to −13.8 V |
 
-:::danger TP5 MUST read negative — the #1 module-killer risk
+<Danger title="TP5 MUST read negative — the #1 module-killer risk">
+
 The **negative rail is the single most dangerous thing on this board to get wrong.** Older
 docs disagree on its topology (there is **no separate −15 V rail** on this build — the old
 LM2586 SEPIC two-step was replaced by U4's direct inversion; ignore "−15 V → −13.5 V"
@@ -206,7 +219,8 @@ Before you trust the −12 V chain or connect *any* module:
 2. If TP5 reads **positive, near 0 V, or +15 V** → the inversion is not working. **Stop.**
    Do not proceed to the −12 V LDO or the output connectors. A positive voltage on what
    should be the −12 V rail destroys modules instantly.
-:::
+
+</Danger>
 
 **Pass**: all three TPs in band, TP5 negative. → Stage 5.
 
@@ -222,11 +236,13 @@ Measure each regulator output, then verify it survives the protection devices to
 | +5 V | U7 L7805ABD2T-TR | +7.5 → +5 | +5.0 V | 4.9–5.1 V |
 | −12 V | U8 CJ7912 | −13.5 → −12 | −12.0 V | −11.75 to −12.25 V |
 
-:::note Headroom flag (watch under load in Stage 6)
+<Note title="Headroom flag (watch under load in Stage 6)">
+
 +12 V and −12 V each have only **1.5 V dropout headroom** — marginal for a 78xx/79xx, which
 can want ~2 V at full load and high temperature. At light load they'll read fine; the risk
 shows up under load (Stage 6). +5 V has a comfortable 2.5 V headroom.
-:::
+
+</Note>
 
 **Protection-device note**: PTC/TVS numbering does **not** follow rail order — **PTC1 = +12 V,
 PTC2 = +5 V, PTC3 = −12 V**. The indicator LED only proves the *regulator output*, not the
@@ -235,13 +251,15 @@ BSMD1206-150-16V, ≈1.5 A hold.)
 
 ### Output connectors — polarity is destruction-critical
 
-:::danger Do NOT trust pin numbers — identify −12 V by meter, every time
+<Danger title="Do NOT trust pin numbers — identify −12 V by meter, every time">
+
 A reversed ribbon swaps +12 V/−12 V and **instantly destroys** modules. The exact pin→net
 mapping on J10/J11 could not be resolved to a number I'd stake a module on (it depends on the
 header's physical orientation, which the board may mount face-down), so **treat pin numbers as
 unverified** and use the procedure below instead. The board's **silkscreen is the authority** —
 it was a hard design requirement — and the meter is the final check.
-:::
+
+</Danger>
 
 **−12 V identification procedure (do this on this first board):**
 
@@ -298,8 +316,9 @@ expected; the LDO is what cleans it up.
 
 ## Stage 8 — Protection test (do last, deliberately)
 
-:::caution Do this knowingly — it stresses the board
-:::
+<Caution title="Do this knowingly — it stresses the board">
+
+</Caution>
 
 - **Overcurrent → PTC**: gradually increase load past the rail's PTC hold current (≈1.5 A).
   The PTC should trip → rail drops → indicator LED off. Remove load; PTC **auto-resets in

--- a/doc/src/content/docs/inbox/v3-bringup-test-procedure.md
+++ b/doc/src/content/docs/inbox/v3-bringup-test-procedure.md
@@ -13,20 +13,13 @@ end), so v3 is the first board where the DC-DC + LDO chain is exercised at all.
 1. **Does the v3 CC-termination fix work?** (external Rd + CC1DB/CC2DB isolation — the v2 killer)
 2. **Does the never-before-tested power chain behave?** (DC-DC + LDO + protection)
 
-These are separable, and you should test them separately. The cleanest way to de-risk
-gamble #2 without depending on #1 is to **inject 15 V from a bench supply at TP1 (VBUS_OUT)**,
-bypassing USB-PD entirely — see Stage 4.
+These are separable, and you should test them separately. The cleanest way to de-risk gamble #2 without depending on #1 is to **inject 15 V from a bench supply at TP1 (VBUS_OUT)**, bypassing USB-PD entirely — see Stage 4.
 
 </Danger>
 
 <Warning title="Before anything: the 20 V hazard">
 
-A **fresh, un-programmed** STUSB4500 advertises **20 V at highest priority**. On a
-20 V-capable PD charger it will negotiate 20 V within ~tens of ms of plug-in and push 20 V
-into a 15 V-rated DC-DC stage. **Never plug an un-programmed board into a full PD charger.**
-Use a current-limited bench supply, a 5 V-only charger, or a no-20V (max 9/15 V) source until
-the NVM is written. (USB-C always starts at 5 V vSafe5V, so the instant of plug-in is safe;
-the danger is the negotiation a few ms later.)
+A **fresh, un-programmed** STUSB4500 advertises **20 V at highest priority**. On a 20 V-capable PD charger it will negotiate 20 V within ~tens of ms of plug-in and push 20 V into a 15 V-rated DC-DC stage. **Never plug an un-programmed board into a full PD charger.** Use a current-limited bench supply, a 5 V-only charger, or a no-20V (max 9/15 V) source until the NVM is written. (USB-C always starts at 5 V vSafe5V, so the instant of plug-in is safe; the danger is the negotiation a few ms later.)
 
 </Warning>
 
@@ -129,12 +122,9 @@ settle = a short; kill power immediately.
 | VREG_2V7 (J3 pad 3) | **2.6–2.8 V** | Chip is alive and configured ("is the chip awake?") |
 | Idle current | settles to a low steady value | No short |
 
-<Warning title="Bench supply at VBUS_IN does **not** power the downstream rails">
+<Warning title="Bench supply at VBUS_IN does NOT power the downstream rails">
 
-VBUS_OUT is gated by Q1 (AO3401A load switch), and Q1 only turns on when the chip asserts
-**VBUS_EN_SNK** after a valid PD contract. Injecting at VBUS_IN with no CC handshake leaves
-Q1 **off**, so the DC-DC chain stays dark. That's expected. To test the power chain
-independently, inject at **VBUS_OUT / TP1** instead — see Stage 4.
+VBUS_OUT is gated by Q1 (AO3401A load switch), and Q1 only turns on when the chip asserts **VBUS_EN_SNK** after a valid PD contract. Injecting at VBUS_IN with no CC handshake leaves Q1 **off**, so the DC-DC chain stays dark. That's expected. To test the power chain independently, inject at **VBUS_OUT / TP1** instead — see Stage 4.
 
 </Warning>
 
@@ -163,9 +153,7 @@ Now the moment v2 failed at. **First, the acceptance test that proves the v3 Rd 
 
 <Tip title="If PD still fails on v3">
 
-Lift **R19** (or R20) to isolate the chip's CC1DB/CC2DB pin from GND — this is exactly why
-0 Ω jumpers (not hard ties) were used. Last resort: hot-air U1 and meter the empty pad
-(OPEN = the short is inside the chip, as in v2).
+Lift **R19** (or R20) to isolate the chip's CC1DB/CC2DB pin from GND — this is exactly why 0 Ω jumpers (not hard ties) were used. Last resort: hot-air U1 and meter the empty pad (OPEN = the short is inside the chip, as in v2).
 
 </Tip>
 
@@ -177,25 +165,13 @@ Lift **R19** (or R20) to isolate the chip's CC1DB/CC2DB pin from GND — this is
 
 <Tip title="Decouple from USB-PD — inject 15 V at TP1 (with one pre-check)">
 
-To test the power chain **without depending on PD**, you can feed a bench supply into
-**TP1 (+) / TP2 (GND)** at **15.0 V, limit ~200–300 mA**. TP1's net is the **`VBUS_OUT`**
-global label (downstream of the Q1 load switch), so this bypasses the USB-PD front end and
-drives the DC-DC + LDO chain directly. `VBUS_OUT` enters the DC-DC sheet as the
-`USB-PD-power IN` hierarchical pin and fans out to U2/U3/U4 VIN (local labels
-`+15V -> +13.5V gen`, `+15V -> +7.5V gen`, `+15V -> -13.5V gen`).
+To test the power chain **without depending on PD**, you can feed a bench supply into **TP1 (+) / TP2 (GND)** at **15.0 V, limit ~200–300 mA**. TP1's net is the **`VBUS_OUT`** global label (downstream of the Q1 load switch), so this bypasses the USB-PD front end and drives the DC-DC + LDO chain directly. `VBUS_OUT` enters the DC-DC sheet as the `USB-PD-power IN` hierarchical pin and fans out to U2/U3/U4 VIN (local labels `+15V -> +13.5V gen`, `+15V -> +7.5V gen`, `+15V -> -13.5V gen`).
 
-**⚠️ Mandatory pre-check before injecting (unpowered, ohmmeter):** measure between **TP1** and
-**U1's VDD pin (J3 pad 4)**.
+**⚠️ Mandatory pre-check before injecting (unpowered, ohmmeter):** measure between **TP1** and **U1's VDD pin (J3 pad 4)**.
 - **Open / high resistance** → TP1 is isolated from the chip supply. **Safe to inject 15 V.**
-- **Continuous (~0 Ω)** → `VBUS_OUT` back-feeds the STUSB4500 supply. **Do NOT inject 15 V at
-  TP1** — you'd put 15 V onto the chip. (The docs conflict: `test-points-v3.md` calls VDD
-  "post-MOSFET load switch," which would mean exactly this back-feed; the netlist trace
-  suggested VDD = VBUS_IN. Resolve it with this meter check before trusting TP1 injection.)
-  In that case, drive the chain through the normal PD path (Stage 3) instead.
+- **Continuous (~0 Ω)** → `VBUS_OUT` back-feeds the STUSB4500 supply. **Do NOT inject 15 V at TP1** — you'd put 15 V onto the chip. (The docs conflict: `test-points-v3.md` calls VDD "post-MOSFET load switch," which would mean exactly this back-feed; the netlist trace suggested VDD = VBUS_IN. Resolve it with this meter check before trusting TP1 injection.) In that case, drive the chain through the normal PD path (Stage 3) instead.
 
-Note: there is **no input fuse** on the VBUS path (the SMD fuses are all on the output rails).
-If you inject and a converter stays dark, confirm 15 V actually reaches *that* converter's VIN
-before suspecting the converter itself.
+Note: there is **no input fuse** on the VBUS path (the SMD fuses are all on the output rails). If you inject and a converter stays dark, confirm 15 V actually reaches *that* converter's VIN before suspecting the converter itself.
 
 </Tip>
 
@@ -209,16 +185,10 @@ Probe each intermediate at its test point:
 
 <Danger title="TP5 MUST read negative — the #1 module-killer risk">
 
-The **negative rail is the single most dangerous thing on this board to get wrong.** Older
-docs disagree on its topology (there is **no separate −15 V rail** on this build — the old
-LM2586 SEPIC two-step was replaced by U4's direct inversion; ignore "−15 V → −13.5 V"
-wording), and the U4 feedback-divider orientation could **not** be resolved from the file.
-Before you trust the −12 V chain or connect *any* module:
+The **negative rail is the single most dangerous thing on this board to get wrong.** Older docs disagree on its topology (there is **no separate −15 V rail** on this build — the old LM2586 SEPIC two-step was replaced by U4's direct inversion; ignore "−15 V → −13.5 V" wording), and the U4 feedback-divider orientation could **not** be resolved from the file. Before you trust the −12 V chain or connect *any* module:
 
 1. Meter TP5 and **confirm the reading is NEGATIVE**, ≈ −13.5 V (band −13.2 to −13.8 V).
-2. If TP5 reads **positive, near 0 V, or +15 V** → the inversion is not working. **Stop.**
-   Do not proceed to the −12 V LDO or the output connectors. A positive voltage on what
-   should be the −12 V rail destroys modules instantly.
+2. If TP5 reads **positive, near 0 V, or +15 V** → the inversion is not working. **Stop.** Do not proceed to the −12 V LDO or the output connectors. A positive voltage on what should be the −12 V rail destroys modules instantly.
 
 </Danger>
 
@@ -238,9 +208,7 @@ Measure each regulator output, then verify it survives the protection devices to
 
 <Note title="Headroom flag (watch under load in Stage 6)">
 
-+12 V and −12 V each have only **1.5 V dropout headroom** — marginal for a 78xx/79xx, which
-can want ~2 V at full load and high temperature. At light load they'll read fine; the risk
-shows up under load (Stage 6). +5 V has a comfortable 2.5 V headroom.
++12 V and −12 V each have only **1.5 V dropout headroom** — marginal for a 78xx/79xx, which can want ~2 V at full load and high temperature. At light load they'll read fine; the risk shows up under load (Stage 6). +5 V has a comfortable 2.5 V headroom.
 
 </Note>
 
@@ -253,11 +221,7 @@ BSMD1206-150-16V, ≈1.5 A hold.)
 
 <Danger title="Do NOT trust pin numbers — identify −12 V by meter, every time">
 
-A reversed ribbon swaps +12 V/−12 V and **instantly destroys** modules. The exact pin→net
-mapping on J10/J11 could not be resolved to a number I'd stake a module on (it depends on the
-header's physical orientation, which the board may mount face-down), so **treat pin numbers as
-unverified** and use the procedure below instead. The board's **silkscreen is the authority** —
-it was a hard design requirement — and the meter is the final check.
+A reversed ribbon swaps +12 V/−12 V and **instantly destroys** modules. The exact pin→net mapping on J10/J11 could not be resolved to a number I'd stake a module on (it depends on the header's physical orientation, which the board may mount face-down), so **treat pin numbers as unverified** and use the procedure below instead. The board's **silkscreen is the authority** — it was a hard design requirement — and the meter is the final check.
 
 </Danger>
 

--- a/doc/src/content/docs/inbox/versioning.md
+++ b/doc/src/content/docs/inbox/versioning.md
@@ -27,11 +27,13 @@ file at the repo root. Bumps are done with the project skills `/l-bump-version-x
 - **Z bump** (`/l-bump-version-z`): a local checkpoint. Creates a **git tag only** (no GitHub
   release).
 
-:::note Non-standard: Y is a lifetime counter
+<Note title="Non-standard: Y is a lifetime counter">
+
 In real semver, the major bump (X) would reset the minor (Y). Here it does **not** — Y is
 defined as "Nth JLCPCB order ever," which keeps climbing across product releases. This is
 intentional. If you'd rather Y reset on an X bump, change `l-bump-version-x`.
-:::
+
+</Note>
 
 ## Mapping from the old v1 / v2 / v3 / v4 labels
 

--- a/doc/src/content/docs/learning/esd-protection-tvs-diodes.md
+++ b/doc/src/content/docs/learning/esd-protection-tvs-diodes.md
@@ -105,7 +105,8 @@ Voltage
 
 ## CC Line ESD Protection
 
-:::info Current Design Uses USBLC6-2SC6
+<Info title="Current Design Uses USBLC6-2SC6">
+
 The v1.1 design uses **[USBLC6-2SC6](../components/usblc6-2sc6.md)** (D4) instead of ESDA25L for CC line protection. USBLC6-2SC6 provides:
 
 - Lower clamping voltage (~17V vs ~44V)
@@ -113,7 +114,8 @@ The v1.1 design uses **[USBLC6-2SC6](../components/usblc6-2sc6.md)** (D4) instea
 - Better suited for USB-C applications
 
 The principles below still apply - only the specific component has changed.
-:::
+
+</Info>
 
 ### Circuit connection (USBLC6-2SC6)
 

--- a/doc/src/content/docs/learning/transformer-polarity-flyback.md
+++ b/doc/src/content/docs/learning/transformer-polarity-flyback.md
@@ -222,11 +222,13 @@ Before PCB assembly:
 
 ## Practical Example: LM2586 Flyback Circuit (Historical Reference)
 
-:::warning Outdated Information
+<Warning title="Outdated Information">
+
 This section describes the **old LM2586 flyback converter design** that has been **replaced** with a simpler **LM2596S inverting buck-boost** topology. This information is kept for educational purposes only.
 
 **Current design**: See Diagram4 (+15V → -13.5V inverting buck-boost using LM2596S U4)
-:::
+
+</Warning>
 
 In the old USB-PD power supply design, the LM2586 flyback converter generated -15V from +15V:
 

--- a/doc/src/content/docs/overview/bom.md
+++ b/doc/src/content/docs/overview/bom.md
@@ -18,9 +18,11 @@ Complete parts configuration using JLCPCB SMT service.
 
 ### Stage 1: USB-PD Voltage Acquisition (STUSB4500)
 
-:::info v1.1 Upgrade
+<Info title="v1.1 Upgrade">
+
 This stage was upgraded from CH224D to **STUSB4500** for significantly improved charger compatibility (~95%+ vs ~33%). See [CH224D](../components/ch224d.md) for the deprecated v1.0 design.
-:::
+
+</Info>
 
 #### Main ICs
 

--- a/doc/src/content/docs/overview/circuit-diagrams.mdx
+++ b/doc/src/content/docs/overview/circuit-diagrams.mdx
@@ -69,9 +69,11 @@ flowchart TD
 
 ## Diagram1: USB-PD Power Supply Section (STUSB4500)
 
-:::info v1.1 Upgrade
+<Info title="v1.1 Upgrade">
+
 This section documents the **STUSB4500-based** design (v1.1). The STUSB4500 is USB-IF certified with ~95%+ charger compatibility. For the deprecated CH224D design (v1.0), see [CH224D documentation](../components/ch224d.md).
-:::
+
+</Info>
 
 ### Diagram1-1: Complete STUSB4500 Circuit with Load Switch
 

--- a/doc/zfb.config.ts
+++ b/doc/zfb.config.ts
@@ -135,8 +135,20 @@ export default defineConfig({
       // Former-Core features (were always-on before zfb next.12).
       // imageEnlarge was a former-Core feature but was hard-removed in zfb
       // next.18 — it is now re-implemented via an MDX p-override.
+      //
       // Admonitions recipe: register the :::name directive vocabulary
       // (note/tip/info/warning/danger/caution/details) → components.
+      //
+      // KNOWN-BROKEN (zfb next.49): the native engine accepts this map (the
+      // loader validates the key + deserializes the entries) but does NOT
+      // transform `:::name` container directives into the mapped components —
+      // they leak through as literal `<p>:::tip[...]</p>` text. `githubAlerts`
+      // (the `> [!NOTE]` path) works, so only the user-directive path is dead.
+      // Upstream bug: Takazudo/zudo-front-builder#1085. Until that lands,
+      // admonitions in the corpus are authored as `<Note>` / `<Tip title="…">`
+      // JSX (which renders correctly) — see doc/CLAUDE.md "Admonitions".
+      // This map is kept so re-enabling `:::` authoring is a one-line revert
+      // once the engine is fixed.
       directives: {
         note: "Note",
         tip: "Tip",


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-pd/issues/66
    - epic: https://github.com/Takazudo/zudo-pd/issues/65
- upstream bug
    - https://github.com/Takazudo/zudo-front-builder/issues/1085

---

## Summary

Every `:::note`/`:::tip`/`:::info`/`:::warning`/`:::danger`/`:::caution` admonition across the docs site rendered as **literal `:::` text** (30 openers, 12 files). Root cause: the **zfb next.49 native engine does not transform `:::` container directives** into the mapped components — confirmed an engine bug, **not** a consumer-config issue (the directives map IS received by the engine; a bogus-key probe dumped the parsed config showing it verbatim, and the `githubAlerts` path works while the directive path is dead).

## Fix

Author admonitions as **JSX** (`<Note>` / `<Tip title="…">`), the proven-working path — JSX components render correctly in plain `.md` (no `.mdx` rename, no internal-link cascade). Converted all 30 openers across the 12 files; rich bodies (bold, lists, links, code, multi-paragraph) render as markdown inside the JSX.

## Changes

- **12 content files**: 30 `:::name [Title]` → `<Tag title="…">…</Tag>`.
- **doc/zfb.config.ts**: keep the now-dead `directives` map (commented) for a one-line revert once upstream lands; document the bug.
- **doc/CLAUDE.md**: authoring rules updated to JSX admonitions; note that admonition/Details JSX works in `.md`.
- Filed upstream: Takazudo/zudo-front-builder#1085.
- Review fix (codex): MDX trims whitespace at soft-break/inline-markup boundaries inside JSX bodies; reflowed the prose-heavy v3-bringup admonitions to single lines, and replaced a `**not**` title with plain-text caps.

## Verification

- `pnpm build` + `pnpm check` (typecheck) pass.
- **0** literal `:::` in `dist/**/*.html`; **30** `data-admonition` blocks across **12** files; titles render; **0** missing-space boundaries in any rendered body.
- Regression-checked: `<Details>` collapsibles and `githubAlerts` (`[!IMPORTANT]`/`[!CAUTION]`) still render.

Closes #66