### PR TITLE
docs: fix -12V rail topology in CLAUDE.md (inverting LM2596, not LM2586 SEPIC)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ The power supply uses a 4-stage architecture:
 2. **DC-DC Stage**: Multiple LM2596S-ADJ converters create intermediate voltages
    - +15V → +13.5V (for +12V rail)
    - +15V → +7.5V (for +5V rail)
-   - +15V → -15V (LM2586SX-ADJ inverted SEPIC) → -13.5V (for -12V rail)
+   - +15V → -13.5V (LM2596S-ADJ in inverting buck-boost configuration) (for -12V rail)
 3. **Linear Regulator Stage**: LM78xx/LM79xx series for final low-noise outputs
    - LM7812: +13.5V → +12V
    - LM7805: +7.5V → +5V


### PR DESCRIPTION
Corrects the DC-DC architecture description in `CLAUDE.md`.

**Was:** `+15V → -15V (LM2586SX-ADJ inverted SEPIC) → -13.5V`
**Now:** `+15V → -13.5V (LM2596S-ADJ in inverting buck-boost configuration)`

**Verified against the schematic:**
- No `LM2586` anywhere in any `.kicad_sch` (the `zudo-pd.kicad_sym` library has no LM2586 symbol).
- All DC-DC stages are `LM2596S-ADJ`; the negative rail (U4) is an inverting LM2596.
- No `-15V` net exists — the inverting regulator produces `-13.5V` directly from `+15V`.

Surfaced by the new `/pd-schematic-review` skill (finding F-9, from epic #68).

Note: the same outdated LM2586/SEPIC description still appears in several `doc/` pages (current-status, quick-reference, overview, v3-bringup, footprint-preview) — left untouched here pending a decision on which mention historical-design context vs. current state.