### PR TITLE
docs: sweep stale LM2586/SEPIC/-15V references in doc/ → inverting LM2596

### DIFF
--- a/doc/src/content/docs/components/lm2596s-adj.mdx
+++ b/doc/src/content/docs/components/lm2596s-adj.mdx
@@ -203,7 +203,29 @@ Vout = 1.23V × (1 + R3/R4)
 - **R4**: 1kΩ ±1% 0603 (JLCPCB: C21190)
 - **C32**: 22nF Ceramic Capacitor (feedback compensation)
 
-### U4: -15V → -13.5V Conversion (for -12V rail)
+### U4: +15V → -13.5V Inverting Buck-Boost (for -12V rail)
+
+<Warning title="Topology corrected (was described as a −15V buck / LM2586 SEPIC)">
+Older docs drew this stage as a buck from a `−15V` intermediate (or an LM2586 SEPIC).
+The actual circuit, verified against the schematic netlist, is a **single inverting
+buck-boost** built from **U4 — an `LM2596S-ADJ`, the same part as U2/U3 (LCSC C347423)**.
+There is **no −15V rail and no LM2586**. In the inverting configuration the IC's GND
+pin floats at the negative output (−13.5V).
+</Warning>
+
+Pin → net, from the schematic netlist:
+
+| U4 pin | Net | Note |
+| --- | --- | --- |
+| 1 Vin | `VBUS_OUT` (+15V) | input, shared with U2/U3 Vin |
+| 2 Output (SW) | `Net-(D3-K)` → L3 + D3 | switch node |
+| 3 GND | `-13.5V OUT` | IC ground floats at −Vout (inverting config) |
+| 4 FB | `Net-(U4-Feedback)` (R5 / R6) | sets −13.5V |
+| 5 ~ON/OFF | `-13.5V OUT` | enabled |
+
+L3 (100µH) returns to GND; D3 (SS34) catches to `-13.5V OUT`; the 470µF bulk cap is across `-13.5V OUT`→GND.
+
+The sketch below is the **superseded `−15V`-buck view**, kept only for reference — it does not reflect the current inverting topology:
 
 ```
 -15V ─────┬─── L3: 100µH ──┬─── D3 ──┬─── C7: 470µF ──┬─→ -13.5V/0.9A

--- a/doc/src/content/docs/how-to/net-table-convention.md
+++ b/doc/src/content/docs/how-to/net-table-convention.md
@@ -62,11 +62,10 @@ levels:
 flowchart TD
   IN["+15V USB-PD input"] -->|"+15V"| DCDC1["DC-DC +13.5V"]
   IN -->|"+15V"| DCDC2["DC-DC +7.5V"]
-  IN -->|"+15V"| DCDC3["DC-DC (inverting) -15V"]
-  DCDC3 -->|"-15V"| DCDC4["DC-DC -13.5V"]
+  IN -->|"+15V"| DCDC3["DC-DC (inverting buck-boost) -13.5V"]
   DCDC1 -->|"+13.5V"| U6["U6 L7812\n+12V LDO"]
   DCDC2 -->|"+7.5V"| U7["U7 L7805\n+5V LDO"]
-  DCDC4 -->|"-13.5V"| U8["U8 CJ7912\n-12V LDO"]
+  DCDC3 -->|"-13.5V"| U8["U8 CJ7912\n-12V LDO"]
 ```
 
 Keep the diagram at the **block level** — one node per functional stage, not

--- a/doc/src/content/docs/inbox/current-status.md
+++ b/doc/src/content/docs/inbox/current-status.md
@@ -25,11 +25,11 @@ USB-C 15V ──┬─→ +13.5V (DC-DC) ──→ +12V (LDO) ──→ +12V OUT
             │
             ├─→ +7.5V  (DC-DC) ──→ +5V  (LDO) ──→ +5V OUT
             │
-            └─→ -15V (Inverter) ──→ -13.5V (DC-DC) ──→ -12V (LDO) ──→ -12V OUT
+            └─→ -13.5V (inverting DC-DC) ──→ -12V (LDO) ──→ -12V OUT
 ```
 
 - ✅ Stage 1: USB-PD Power Supply (STUSB4500)
-- ✅ Stage 2: DC-DC Converters (LM2596S × 3 + LM2586 inverted SEPIC)
+- ✅ Stage 2: DC-DC Converters (LM2596S-ADJ × 3: two buck + one inverting buck-boost)
 - ✅ Stage 3: Linear Regulators (LM7812/7805/7912)
 - ✅ Stage 4: Protection Circuit (PTC + Fuse + TVS)
 
@@ -38,8 +38,8 @@ USB-C 15V ──┬─→ +13.5V (DC-DC) ──→ +12V (LDO) ──→ +12V OUT
 **All parts confirmed**: All JLCPCB part numbers finalized
 
 - ✅ USB-PD Controller: STUSB4500 (C2678061)
-- ✅ DC-DC Converter: LM2596S-ADJ × 3 (C347423)
-- ✅ Voltage Inverter: LM2586SX-ADJ/NOPB (C181324)
+- ✅ DC-DC Converters (buck): LM2596S-ADJ × 2 (C347423) — U2 +13.5V, U3 +7.5V
+- ✅ Voltage Inverter: LM2596S-ADJ (C347423), inverting buck-boost — U4 -13.5V (same part as the bucks; no separate LM2586/-15V stage)
 - ✅ Linear Regulators: L7812CV-DG (C2914) / L7805ABD2T-TR (C86206) / CJ7912 (C94173)
 - ✅ Inductors: 100µH 4.5A × 3 (C19268674)
 - ✅ TVS Diodes: SMAJ15A, SD05

--- a/doc/src/content/docs/misc/footprint-preview.md
+++ b/doc/src/content/docs/misc/footprint-preview.md
@@ -108,7 +108,7 @@ Click on any footprint to view it in fullscreen.
 **Package:** 0603 (1.6mm × 0.8mm)
 **Used for:**
 
-- Ceramic capacitors (470nF for CH224D, 47nF for LM2586 compensation)
+- Ceramic capacitors (470nF for CH224D, 22nF for LM2596 feedback compensation)
 - High-frequency decoupling throughout circuit
   **Typical values:** 10µF, 470nF, 100nF, 47nF
   **Applications:** IC power supply decoupling, bypass capacitors, compensation networks


### PR DESCRIPTION
Follow-up to #80. Sweeps the remaining doc pages that described the negative rail as an LM2586 SEPIC / `-15V` two-step.

**Verified from the schematic netlist** (`kicad-cli sch export netlist`):
- Only **3** LM2596S-ADJ exist (U2 +13.5V, U3 +7.5V, **U4 inverter**). No 4th IC.
- **U4** = LM2596S-ADJ (C347423), Vin on `VBUS_OUT` (+15V), GND pin tied to `-13.5V OUT` → textbook **inverting buck-boost**, +15V → −13.5V directly.
- **No `-15V` net** and **no LM2586 (C181324)** anywhere in schematic/symbols/BOM.

**Fixed (current-state):**
- `inbox/current-status.md` — architecture ASCII, stage-2 summary, and the BOM line (LM2586SX-ADJ/NOPB C181324 → LM2596S-ADJ C347423).
- `how-to/net-table-convention.md` — approach-A Mermaid (inverting → −13.5V).
- `components/lm2596s-adj.mdx` — U4 heading + a verified pin→net table + correction note; old −15V-buck sketch flagged superseded.
- `misc/footprint-preview.md` — 47nF/LM2586 comp → 22nF/LM2596 feedback compensation.

**Left intact (historical / design-exploration):** `transformer-polarity-flyback.md` (already marked replaced), `quick-reference.md` ("previous LM2586 flyback design"), `v3-bringup-test-procedure.md` (already correct), and the trial finding in `ai-circuit-design-research.md`. Also left `test-points-v3.md` (superseded v3 TP plan, already corrected by v3-bringup) and `kicad-workflow.md` (generic net-label example).

Doc site builds (65 pages) + typechecks clean. Surfaced by `/pd-schematic-review` (F-9, epic #68).