### PR TITLE
docs: finish inverter sweep — remaining -15V ASCII + stale ICL7660 doc text

### DIFF
--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -190,7 +190,7 @@ USB-C 15V ──┬─→ +13.5V (DC-DC) ──→ +12V (LDO) ──→ +12V OUT
             │
             ├─→ +7.5V  (DC-DC) ──→ +5V  (LDO) ──→ +5V OUT
             │
-            └─→ -15V (Inverter) ──→ -13.5V (DC-DC) ──→ -12V (LDO) ──→ -12V OUT
+            └─→ -13.5V (inverting DC-DC) ──→ -12V (LDO) ──→ -12V OUT
 ```
 
 ### 3. Generating Circuit / Footprint SVGs

--- a/doc/src/content/docs/components/ptc-12v-neg.md
+++ b/doc/src/content/docs/components/ptc-12v-neg.md
@@ -48,7 +48,7 @@ The JK-nSMD100/16V is a PTC resettable fuse providing automatic overcurrent prot
 
 ```
 Layer 1: USB-PD Adapter → Overcurrent protection
-Layer 2: ICL7660M (-15V inverter) + LM2596S #3 → Current limiting
+Layer 2: U4 LM2596S-ADJ inverting buck-boost (+15V → -13.5V) → Current limiting
 Layer 3: LM7912 Linear Regulator → Current limiting ~1A, thermal shutdown
 Layer 4: This PTC (1.0A hold / 2.0A trip) → Auto-reset protection
     ↓

--- a/doc/src/content/docs/overview/bom.md
+++ b/doc/src/content/docs/overview/bom.md
@@ -81,7 +81,7 @@ This stage was upgraded from CH224D to **STUSB4500** for significantly improved 
 - **Soft-start** via C35 (100nF) limits inrush current (τ = 56kΩ × 100nF = 5.6ms)
 - **NVM programming** required to configure 15V PDO (one-time setup)
 
-### Stage 2: DC-DC Converters (LM2596S-ADJ × 3 + ICL7660)
+### Stage 2: DC-DC Converters (LM2596S-ADJ × 3: U2/U3 buck, U4 inverting buck-boost)
 
 #### Main ICs
 

--- a/doc/src/content/docs/overview/usb-pd-adapter.md
+++ b/doc/src/content/docs/overview/usb-pd-adapter.md
@@ -190,7 +190,7 @@ When connecting zudo-PD to an incompatible charger:
 2. All LEDs turn off
 3. No output voltage on any rail
 
-**Explanation:** With only 5V input (failed negotiation), the DC-DC converters cannot produce proper voltages. The ICL7660 voltage inverter briefly attempts to invert whatever voltage exists, causing the -12V LED to flicker momentarily.
+**Explanation:** With only 5V input (failed negotiation), the DC-DC converters cannot produce proper voltages. The U4 inverting buck-boost (LM2596S-ADJ) briefly attempts to invert whatever voltage exists, causing the -12V LED to flicker momentarily.
 
 ### Recommendations
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ USB-C 15V ──┬─→ +13.5V (DC-DC) ──→ +12V (LDO) ──→ +12V OUT
             │
             ├─→ +7.5V  (DC-DC) ──→ +5V  (LDO) ──→ +5V OUT
             │
-            └─→ -15V (Inverter) ──→ -13.5V (DC-DC) ──→ -12V (LDO) ──→ -12V OUT
+            └─→ -13.5V (inverting DC-DC) ──→ -12V (LDO) ──→ -12V OUT
 ```
 
 **DC-DC + LDO Two-Stage Design**: Balancing efficiency and noise


### PR DESCRIPTION
Extends #80 / #81. The negative-rail inverter had been documented as **three different parts** over time — LM2586 SEPIC, ICL7660M charge-pump, and the actual **U4 (LM2596S-ADJ inverting buck-boost)**. The schematic netlist confirms only U2/U3/U4 = LM2596S-ADJ; no ICL7660 and no LM2586 components exist on the board.

**Fixed (doc text, current-state):**
- `readme.md`, `doc/CLAUDE.md` — architecture ASCII (−15V two-step → direct inverting −13.5V).
- `overview/bom.md` — stage-2 header said "+ ICL7660" while the table already lists U4 as LM2596S-ADJ.
- `components/ptc-12v-neg.md` — "ICL7660M (−15V inverter)" → U4 LM2596S-ADJ inverting buck-boost.
- `overview/usb-pd-adapter.md` — debug narrative "ICL7660 voltage inverter" → U4 inverting buck-boost.

**Deliberately NOT touched (needs a human/library decision):** ICL7660M still appears in the footprint **library** docs — `footprints/README.md`, `footprints/kicad/README.md` (LCSC `C356724` + a `SOP-8` `.kicad_mod` + datasheet) — and `how-to/kicad-parts-download.md`. Removing those is a library-maintenance call, not doc cleanup.

Doc site builds (65 pages) clean.