### PR TITLE
docs: fix overview.md + lm2596 efficiency line (inverting LM2596)

### DIFF
--- a/doc/src/content/docs/components/lm2596s-adj.mdx
+++ b/doc/src/content/docs/components/lm2596s-adj.mdx
@@ -394,7 +394,7 @@ Since all three converters use the same IC, switching frequency, inductor, and o
 
 - U2 (15V→13.5V): ~88% (High efficiency due to small voltage difference)
 - U3 (15V→7.5V): ~85% (Moderate voltage difference)
-- U4 (-15V→-13.5V): ~88% (Equivalent efficiency for negative voltage)
+- U4 (+15V→-13.5V inverting): ~88% (Equivalent efficiency for negative voltage)
 
 ### 8. ON/OFF Pin Configuration
 

--- a/doc/src/content/docs/overview/overview.md
+++ b/doc/src/content/docs/overview/overview.md
@@ -36,7 +36,7 @@ USB-C 15V ──┬─→ +13.5V (DC-DC) ──→ +12V (LDO) ──→ +12V OUT
             │
             ├─→ +7.5V  (DC-DC) ──→ +5V  (LDO) ──→ +5V OUT
             │
-            └─→ -15V (Inverter) ──→ -13.5V (DC-DC) ──→ -12V (LDO) ──→ -12V OUT
+            └─→ -13.5V (inverting DC-DC) ──→ -12V (LDO) ──→ -12V OUT
 ```
 
 #### Stage 1: USB-PD Power Delivery
@@ -47,11 +47,10 @@ USB-C 15V ──┬─→ +13.5V (DC-DC) ──→ +12V (LDO) ──→ +12V OUT
 
 #### Stage 2: DC-DC Converter
 
-- **LM2596S-ADJ × 3**: High-efficiency buck converter
-  - +15V → +13.5V (for +12V rail)
-  - +15V → +7.5V (for +5V rail)
-  - -15V → -13.5V (for -12V rail)
-- **LM2586SX-ADJ**: Inverted SEPIC converter (+15V → -15V, 3A capable)
+- **LM2596S-ADJ × 3**: adjustable switching regulators (U2/U3 buck, U4 inverting)
+  - +15V → +13.5V buck (for +12V rail)
+  - +15V → +7.5V buck (for +5V rail)
+  - +15V → -13.5V inverting buck-boost (for -12V rail) — no separate LM2586/SEPIC, no -15V rail
 - **Efficiency**: Approx. 85-90%
 
 #### Stage 3: Linear Regulator


### PR DESCRIPTION
Two edits from the inverter doc sweep (#80/#81/#82) that were missed by those commits. `overview.md`: architecture ASCII (−15V two-step → direct inverting −13.5V) + stage-2 list (removed phantom LM2586 SEPIC; U4 is the 3rd LM2596 in inverting buck-boost). `lm2596s-adj.mdx`: efficiency-table U4 label. Netlist-verified; doc builds clean.