### PR TITLE
fix(content): give admonition blocks bottom spacing

### DIFF
--- a/doc/src/styles/global.css
+++ b/doc/src/styles/global.css
@@ -499,6 +499,10 @@ body {
   border-left: 4px solid var(--color-muted);
   /* Asymmetric padding mirrors the Astro reference: generous top, snug bottom. */
   padding: var(--spacing-vsp-md) var(--spacing-hsp-lg) var(--spacing-vsp-2xs);
+  /* Snug bottom *padding* keeps the body tight inside the box; this margin
+   * supplies the external gap to the next block, matching every other
+   * .zd-content content block (paragraphs zero their own margin-top). */
+  margin-bottom: var(--spacing-vsp-md);
   background-color: color-mix(in srgb, var(--color-muted) 12%, var(--color-bg));
   border-radius: 0 var(--radius-DEFAULT) var(--radius-DEFAULT) 0;
 }


### PR DESCRIPTION
## Problem

On rendered doc pages, a Note/admonition box (any element matching `[data-admonition]`) has no bottom spacing: the next paragraph butts directly against the bottom of the box, with zero separating gap. Found during testing.

## Root cause

`doc/src/styles/global.css` uses a per-element-margin spacing model: each content block (`.zd-content :where(p)`, `:where(ul)`, `:where(ol)`, `:where(blockquote)`, `:where(table)`, ...) carries its own `margin-bottom: var(--spacing-vsp-md)`. Paragraphs additionally set `margin-top: 0`, which defeats the `.zd-content > :where(* + *)` flow rule for the paragraph that follows a block.

The `[data-admonition]` rule set only `border-left`, `padding`, `background-color`, and `border-radius` — it was the **only** content block with no `margin-bottom`. So when an admonition is immediately followed by a paragraph, the admonition contributes no bottom margin and the paragraph's top margin is zeroed, producing a zero gap. (Admonition → heading still gapped, because headings carry their own `margin-top` — matching the observed symptom.)

## Fix

Add `margin-bottom: var(--spacing-vsp-md);` to the `[data-admonition]` rule so admonitions participate in the same content rhythm as every other block. The snug bottom *padding* still keeps the body tight inside the box; the new margin supplies the external gap to the next block. No other rule, the spacing model, headings, or paragraphs were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)