### PR TITLE
chore: replace dead husky/lint-staged with lefthook + mdx-formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 /doc/build
 /doc/.cache-loader
 
+# Legacy husky artifacts (replaced by lefthook; local hooksPath overrides
+# from old installs may still generate these on disk)
+.husky/
+doc/.husky/
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-cd doc
-pnpm exec lint-staged

--- a/doc/.husky/pre-commit
+++ b/doc/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd doc && pnpm exec lint-staged && pnpm run typecheck && pnpm run lint

--- a/doc/CLAUDE.md
+++ b/doc/CLAUDE.md
@@ -24,11 +24,21 @@ deployed to **Cloudflare Workers**.
 ## Local Development
 
 ```bash
-pnpm dev        # dev server at http://localhost:4321
-pnpm build      # production build → dist/ (incl. dist/_worker.js)
-pnpm preview    # preview the built dist/
-pnpm check      # TypeScript typecheck
+pnpm dev             # dev server at http://localhost:4321
+pnpm build           # production build → dist/ (incl. dist/_worker.js)
+pnpm preview         # preview the built dist/
+pnpm check           # TypeScript typecheck
+pnpm format:md       # format src/content/docs/**/*.{md,mdx} in place
+pnpm format:md:check # check formatting without writing
 ```
+
+### Git Hooks (lefthook)
+
+Repo-root `lefthook.yml` wires a pre-commit hook that auto-formats staged
+`doc/src/content/docs/**/*.{md,mdx}` files via `@takazudo/mdx-formatter`
+(pinned in `scripts/mdx-format.sh`), and a pre-push hook that runs `pnpm
+check` when pushing to `main`. Hooks install automatically via the `doc`
+package's `prepare` script on `pnpm install`.
 
 ### URL Reference Guidelines
 

--- a/doc/package.json
+++ b/doc/package.json
@@ -9,7 +9,10 @@
     "preview": "zfb preview",
     "check": "zfb check",
     "check:html": "html-validate \"dist/**/*.html\"",
-    "b4push": "pnpm check && pnpm build"
+    "b4push": "pnpm check && pnpm build",
+    "format:md": "../scripts/mdx-format.sh --write \"src/content/docs/**/*.{md,mdx}\"",
+    "format:md:check": "../scripts/mdx-format.sh --check \"src/content/docs/**/*.{md,mdx}\"",
+    "prepare": "cd .. && [ -d .git ] && lefthook install || true"
   },
   "dependencies": {
     "@takazudo/zfb": "0.1.0-next.49",
@@ -38,6 +41,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
     "html-validate": "^10.0.0",
+    "lefthook": "^2.1.9",
     "pagefind": "^1.4.0",
     "tsx": "^4.21.0"
   },

--- a/doc/package.json
+++ b/doc/package.json
@@ -12,7 +12,7 @@
     "b4push": "pnpm check && pnpm build",
     "format:md": "../scripts/mdx-format.sh --write \"src/content/docs/**/*.{md,mdx}\"",
     "format:md:check": "../scripts/mdx-format.sh --check \"src/content/docs/**/*.{md,mdx}\"",
-    "prepare": "cd .. && [ -d .git ] && lefthook install || true"
+    "prepare": "cd .. && lefthook install --reset-hooks-path"
   },
   "dependencies": {
     "@takazudo/zfb": "0.1.0-next.49",

--- a/doc/pnpm-lock.yaml
+++ b/doc/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       html-validate:
         specifier: ^10.0.0
         version: 10.17.0
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
       pagefind:
         specifier: ^1.4.0
         version: 1.5.2
@@ -1178,6 +1181,60 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2605,6 +2662,49 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/doc/pnpm-workspace.yaml
+++ b/doc/pnpm-workspace.yaml
@@ -1,9 +1,11 @@
 # pnpm 11+ reads build-script approval from here (pnpm 11 ignores the
 # package.json "pnpm" field; package.json keeps onlyBuiltDependencies for
 # pnpm 10 CI). esbuild is used by zfb's bundler; sharp backs image probing;
-# workerd backs the Cloudflare adapter build.
+# workerd backs the Cloudflare adapter build; lefthook's postinstall fetches
+# its platform binary.
 allowBuilds:
   esbuild: true
+  lefthook: true
   sharp: true
   workerd: true
 # pnpm 11.5.2's default minimumReleaseAge gate (~24h cooldown) rejects packages

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,4 @@
 pre-commit:
-  parallel: true
   commands:
     format-mdx:
       glob: 'doc/src/content/docs/**/*.{md,mdx}'

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,18 @@
+pre-commit:
+  parallel: true
+  commands:
+    format-mdx:
+      glob: 'doc/src/content/docs/**/*.{md,mdx}'
+      stage_fixed: true
+      run: ./scripts/mdx-format.sh --write {staged_files}
+
+pre-push:
+  commands:
+    check-doc:
+      run: |
+        BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+        if [ "$BRANCH" = "main" ]; then
+          echo "Running doc quality checks before pushing to main..."
+          pnpm -C doc run check || exit 1
+          echo "Quality checks passed!"
+        fi

--- a/scripts/mdx-format.sh
+++ b/scripts/mdx-format.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Wrapper for @takazudo/mdx-formatter -- pin the version in one place.
+pnpm dlx @takazudo/mdx-formatter@1.2.1 "$@"

--- a/scripts/mdx-format.sh
+++ b/scripts/mdx-format.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wrapper for @takazudo/mdx-formatter -- pin the version in one place.
 pnpm dlx @takazudo/mdx-formatter@1.2.1 "$@"


### PR DESCRIPTION
## Summary

The repo's git pre-commit hook was silently broken: `core.hooksPath` pointed at a
husky setup (`doc/.husky/`) left over from the pre-`zfb` Docusaurus era, calling
`pnpm exec lint-staged` (not installed) and `pnpm run lint` (script no longer
exists). Any commit would fail unless `--no-verify` was used.

This replaces it with [lefthook](https://github.com/evilmartians/lefthook) as the
hook manager, and wires up `@takazudo/mdx-formatter` to auto-format the doc site's
markdown/MDX content — patterned after another project's reference setup for the
same pair of tools.

## Changes

- Remove dead `.husky/` (root) and `doc/.husky/` (tracked files); both were
  superseded by `zfb` scaffolding a while back and no longer functioned.
- Add root `lefthook.yml`:
  - `pre-commit`: formats staged `doc/src/content/docs/**/*.{md,mdx}` via the new
    `scripts/mdx-format.sh` wrapper (pins `@takazudo/mdx-formatter` in one place).
  - `pre-push`: runs `pnpm -C doc run check` (typecheck) only when pushing to `main`.
- `doc/package.json`: add `lefthook` devDependency; `prepare` script runs
  `lefthook install --reset-hooks-path` — this both installs the hooks and clears
  the stale `core.hooksPath` left by the old husky setup (lefthook's own documented
  fix for this migration case; a plain `lefthook install` would otherwise exit
  non-zero on a machine still carrying that override). Also adds `format:md` /
  `format:md:check` scripts.
- `doc/pnpm-workspace.yaml`: approve `lefthook`'s postinstall under pnpm 11's
  `allowBuilds` gate (package.json's `onlyBuiltDependencies` already listed it,
  a stale leftover from before this — now it's actually wired up).
- `.gitignore`: ignore `.husky/` / `doc/.husky/` (leftover local artifacts from
  the old setup).
- `doc/CLAUDE.md`: document the new scripts and hook behavior.

## Test Plan

- [x] `pnpm -C doc install` — installed lefthook, reset the stale local
      `core.hooksPath`, and wrote real hook shims into `.git/hooks/`.
- [x] Manually ran `lefthook run pre-commit` against a scratch `.md` file with
      formatting issues staged — confirmed it reformatted the file and
      re-staged the fix (`stage_fixed: true`).
- [x] `pnpm -C doc run check` and `pnpm -C doc run format:md:check` both run
      correctly standalone.
- [x] Made **real** commits on this branch (no `--no-verify`) both before and
      after resetting hooksPath — pre-commit hook ran for real both times.
- [x] Pushed this branch for real (twice) — pre-push hook ran for real,
      correctly skipping the `main`-only check on a topic branch.
- [x] Two independent reviews (codex timed out mid-run; fell back to 2 Opus
      reviewers) — findings applied: `prepare` now uses lefthook's own
      `--reset-hooks-path` instead of a `[ -d .git ] && ... || true` guard that
      silently swallowed a real failure and broke in worktrees.
- [ ] CI (`main-deploy.yml` typecheck/build) — no PR checks are configured
      (that workflow only triggers on push to `main`); not otherwise re-run.

Filed #98 as a separate follow-up for 9 pre-existing doc files that
`format:md:check` flags as not matching the formatter's output (out of scope for
this tooling-setup PR; `format:md:check` is intentionally not wired into `check`
yet so it doesn't break `main` on unrelated pre-existing content).