### PR TITLE
docs: run mdx-formatter pass over existing content

### DIFF
--- a/doc/src/content/docs/components/stusb4500.md
+++ b/doc/src/content/docs/components/stusb4500.md
@@ -276,7 +276,6 @@ R12 was changed from 33kΩ to 56kΩ to provide adequate Vgs margin for Q1:
 
 <Tip title="Why USBLC6-2SC6?">
 
-
 - **Low clamping voltage** (~17V) - better protection for CC lines operating at ~1.7V
 - **Includes VBUS protection** - pin 5 can connect to VBUS_IN for additional transient protection
 - **USB-specific design** - optimized for USB-C applications
@@ -372,9 +371,7 @@ This eliminates inrush current issues during PD negotiation.
 Three issues were found in the v1 PCBA that prevented STUSB4500 from operating correctly:
 
 1. **VBUS_VS_DISCH (pin 18) not connected**: Pin 18 was left as NC (no connection). The datasheet requires this pin to be connected to VBUS_IN through a 470ohm series resistor for VBUS voltage sensing and discharge. Fixed by adding R14 (470ohm) between VBUS_IN and pin 18.
-
 2. **VSYS (pin 22) shorted to VREG_2V7 (pin 23)**: A routing error connected pin 22 (VSYS input) to pin 23 (VREG_2V7 regulator output), overloading the internal 2.7V regulator. Fixed by cutting the trace and wiring VSYS to GND.
-
 3. **VSYS (pin 22) left floating**: After the trace cut fix above, VSYS was left floating instead of being connected to GND. The datasheet recommends grounding VSYS when not used. Fixed by adding a bodge wire from pin 22 to GND.
 
 For full details, see the [PCBA v1 Debug Report](../inbox/pcba-v1-debug.md).

--- a/doc/src/content/docs/how-to/kicad-jlcpcb-tools.md
+++ b/doc/src/content/docs/how-to/kicad-jlcpcb-tools.md
@@ -85,14 +85,14 @@ If you find a missing or wrong correction, use the plugin's **Corrections Manage
 1. In the JLCPCB Tools panel, click **Generate**.
 2. The plugin produces a `jlcpcb/` directory at the project root containing:
 
-```
-jlcpcb/
-├── gerber/                    ← Gerber files (one per layer)
-├── production_files/
-│   ├── BOM-zudo-pd.csv        ← BOM with LCSC numbers
-│   └── POS-zudo-pd.csv        ← Pick-and-place / CPL with corrected rotations
-└── project.db                 ← Plugin local cache (SQLite)
-```
+   ```
+   jlcpcb/
+   ├── gerber/                    ← Gerber files (one per layer)
+   ├── production_files/
+   │   ├── BOM-zudo-pd.csv        ← BOM with LCSC numbers
+   │   └── POS-zudo-pd.csv        ← Pick-and-place / CPL with corrected rotations
+   └── project.db                 ← Plugin local cache (SQLite)
+   ```
 
 3. Zip the contents of `jlcpcb/gerber/` for upload (JLCPCB expects a single `.zip` of Gerbers).
 4. Upload to the JLCPCB order page:

--- a/doc/src/content/docs/how-to/kicad-workflow.md
+++ b/doc/src/content/docs/how-to/kicad-workflow.md
@@ -225,7 +225,6 @@ zudo-pd/          ← Repository root
 - Or from PCB Editor: Preferences → Manage Footprint Libraries
 
 2. **Click "Project Specific Libraries" tab** (at bottom)
-
 3. **Add new library:**
 - Click folder icon (➕) to add library
 - Set values:

--- a/doc/src/content/docs/inbox/nvm-programming.md
+++ b/doc/src/content/docs/inbox/nvm-programming.md
@@ -229,6 +229,7 @@ Symptom of wrong choice: GUI shows "STM32-Nucleo-board not Detected" even after 
 </Warning>
 
 Sources:
+
 - [STSW-STUSB002 quick start guide (PDF)](https://www.st.com/resource/en/product_presentation/stswstusb002_quick_start_v3_2.pdf) — explicit UART vs HID guidance
 - [NUCLEO-F072RB schematic (MB1136-C03)](https://www.st.com/resource/en/schematic_pack/mb1136-default-c03_schematic.pdf) — confirms CN1 is ST-Link only
 
@@ -307,14 +308,14 @@ Once detected, the "Read device NVM" and "Write device NVM" buttons appear in th
 2. The "SNK Parameters" tab will populate with the factory defaults — confirm they match the expected defaults (PDO1: 5V/1.5A, PDO2: 15V/1.5A, PDO3: 20V/1.0A)
 3. Configure target settings:
 
-| Field | New value | Reason |
-| --- | --- | --- |
-| **SNK_PDO_NUMB** | **`2`** | Only advertise PDO1 + PDO2. PDO3 (20V) never negotiated. |
-| **PDO2 Current** | **`3.00 A`** | Design needs 3A on the 15V rail |
-| **POWER_ONLY_ABOVE_5V** | **checked** | VBUS_EN_SNK only enables after 15V negotiated |
-| PDO1 (5V/1.5A) | keep | Mandatory USB-PD default |
-| PDO2 Voltage (15V) | keep | Target rail voltage |
-| Other settings | leave alone | Don't touch FLEX_I, UVLO/OVLO, GPIO, etc. |
+   | Field | New value | Reason |
+   | --- | --- | --- |
+   | **SNK_PDO_NUMB** | **`2`** | Only advertise PDO1 + PDO2. PDO3 (20V) never negotiated. |
+   | **PDO2 Current** | **`3.00 A`** | Design needs 3A on the 15V rail |
+   | **POWER_ONLY_ABOVE_5V** | **checked** | VBUS_EN_SNK only enables after 15V negotiated |
+   | PDO1 (5V/1.5A) | keep | Mandatory USB-PD default |
+   | PDO2 Voltage (15V) | keep | Target rail voltage |
+   | Other settings | leave alone | Don't touch FLEX_I, UVLO/OVLO, GPIO, etc. |
 
 4. Verify "**Verify after write**" checkbox at top-right is checked (default)
 5. Click **"Write device NVM"**

--- a/doc/src/content/docs/inbox/pcba-v2-debug.md
+++ b/doc/src/content/docs/inbox/pcba-v2-debug.md
@@ -167,6 +167,7 @@ An earlier draft of this fix proposed 10 kΩ as a hedge in case a future chip ba
 The "good chip" parallel-resistance failure mode is **not** solved by picking a compromise external value — the proper fix is to **remove the external Rd entirely** (board respin, or a populate/DNP jumper) once you know the chip's internal Rd is healthy. So for v3 we use the spec value and don't try to compromise across two failure scenarios.
 
 **Sensitivity on 3 A USB-C sources:** sources advertising 3 A use Rp = 22 kΩ (tightest detection). The CC line voltage with Rp pull-up:
+
 - 5.1 kΩ Rd → 5 V × 5.1 / (5.1 + 22) ≈ **0.94 V** — comfortably below the ~1.7 V "sink connected" threshold
 - 10 kΩ Rd → 5 V × 10 / (10 + 22) ≈ **1.56 V** — borderline; some compliant sources will fail to detect
 
@@ -175,6 +176,7 @@ The "good chip" parallel-resistance failure mode is **not** solved by picking a 
 **This is the critical change.** If CC1DB stays on the CC1 net (v2 wiring), then a chip with internally-shorted CC1DB still drags the entire CC1 net to 0 Ω, and the external 5.1 kΩ is overpowered (a 0 Ω short wins against any finite resistor). The fault persists.
 
 By routing CC1DB and CC2DB to GND directly:
+
 - The broken pin's internal short is isolated to the GND net (harmless)
 - The CC1 / CC2 nets see only the external R_CC1 / R_CC2 and the chip's main CC pins (pin 2, pin 4) for termination
 

--- a/doc/src/content/docs/inbox/v3-bringup-test-procedure.md
+++ b/doc/src/content/docs/inbox/v3-bringup-test-procedure.md
@@ -1,5 +1,5 @@
 ---
-title: "v3 Bring-Up & Test Procedure"
+title: v3 Bring-Up & Test Procedure
 sidebar_position: 9
 ---
 
@@ -182,6 +182,7 @@ Lift **R19** (or R20) to isolate the chip's CC1DB/CC2DB pin from GND — this is
 To test the power chain **without depending on PD**, you can feed a bench supply into **TP1 (+) / TP2 (GND)** at **15.0 V, limit ~200–300 mA**. TP1's net is the **`VBUS_OUT`** global label (downstream of the Q1 load switch), so this bypasses the USB-PD front end and drives the DC-DC + LDO chain directly. `VBUS_OUT` enters the DC-DC sheet as the `USB-PD-power IN` hierarchical pin and fans out to U2/U3/U4 VIN (local labels `+15V -> +13.5V gen`, `+15V -> +7.5V gen`, `+15V -> -13.5V gen`).
 
 **⚠️ Mandatory pre-check before injecting (unpowered, ohmmeter):** measure between **TP1** and **U1's VDD pin (J3 pad 4)**.
+
 - **Open / high resistance** → TP1 is isolated from the chip supply. **Safe to inject 15 V.**
 - **Continuous (~0 Ω)** → `VBUS_OUT` back-feeds the STUSB4500 supply. **Do NOT inject 15 V at TP1** — you'd put 15 V onto the chip. (The docs conflict: `test-points-v3.md` calls VDD "post-MOSFET load switch," which would mean exactly this back-feed; the netlist trace suggested VDD = VBUS_IN. Resolve it with this meter check before trusting TP1 injection.) In that case, drive the chain through the normal PD path (Stage 3) instead.
 
@@ -332,6 +333,7 @@ R19/R20 (C21189). Chip-side signals broken out on **J3** 1×8 pogo block
 (1:CC1DB 2:CC2DB 3:VREG_2V7 4:VDD 5:RESET 6:ATTACH 7:PD_OK 8:VBUS_EN_SNK).
 
 **Open flags to keep in mind:**
+
 - +12 V / −12 V LDO headroom is **1.5 V** — marginal; watch under load.
 - U4 negative-feedback exact value/sign unresolved from the file — **confirm at TP5 on the bench.**
 - TP6–TP9 (CC1/CC2/−15V/VBUS_DISCH individual pads) were **planned but not placed** — only

--- a/doc/src/content/docs/inbox/v4-asbuilt-audit.md
+++ b/doc/src/content/docs/inbox/v4-asbuilt-audit.md
@@ -84,9 +84,7 @@ on/after 2026-06-05 for this board. If one exists:
 3. Re-run the D4/U1/R-value comparison in this doc against the confirmed BOM, not just the
    locally-generated one, since JLCPCB can silently substitute out-of-stock basic parts.
 
-If no such order exists, v0.4.0 has **not** been manufactured yet — the fix exists only in git
-+ the local `jlcpcb/` export, and the next actionable step is to actually place the order using
-the recovered files in `jlcpcb-order-snapshots/v0_4_0/used-for-order/` (below).
+If no such order exists, v0.4.0 has **not** been manufactured yet — the fix exists only in git and the local `jlcpcb/` export, and the next actionable step is to actually place the order using the recovered files in `jlcpcb-order-snapshots/v0_4_0/used-for-order/` (below).
 
 ### BOM comparison: front-end parts
 

--- a/doc/src/content/docs/learning/ai-circuit-design-research.md
+++ b/doc/src/content/docs/learning/ai-circuit-design-research.md
@@ -146,6 +146,7 @@ Full findings: `experiments/ai-circuit-design/circuit-synth-spike/FINDINGS.md`
 **What worked:** The review confirmed the v3 fix is present: `VBUS_IN → R14 (470 Ω) → U1.18` with no GND on the pin-18 net (F-1). Feedback-divider math recomputed from the actual resistors matched the target rails to within 0.22 % (F-7). Load-switch polarity, VDD decoupling, CC Rd pull-downs, and VREG decaps all checked out.
 
 **What was flagged:**
+
 - Both the +12V (L7812, F-11) and −12V (CJ7912, F-13) LDOs run at only ~1.5 V dropout against a ~2 V typical spec — marginal at rated current. The existing `components/l7812cv.md` doc already flags this.
 - Documentation discrepancy (F-9): `CLAUDE.md` and the architecture text describe the negative rail as "−15V (LM2586SX-ADJ inverted SEPIC)," but the actual schematic uses a third `LM2596S-ADJ` in an inverting buck-boost topology — a stale description that should be corrected.
 

--- a/doc/src/content/docs/misc/footprint-preview.md
+++ b/doc/src/content/docs/misc/footprint-preview.md
@@ -11,7 +11,6 @@ Click on any footprint to view it in fullscreen.
 
 ### U1 - CH224D USB PD Controller
 
-
 ![CH224D QFN-20 Package](/footprints/QFN-20_L3.0-W3.0-P0.40-BL-EP1.7.svg)
 
 **Designator:** U1
@@ -21,7 +20,6 @@ Click on any footprint to view it in fullscreen.
 **Function:** Negotiates 15V from USB-C PD adapter
 
 ### J1 - USB Type-C Connector
-
 
 ![USB Type-C 6P Connector](/footprints/TYPE-C-SMD_TYPE-C-6P.svg)
 
@@ -37,7 +35,6 @@ Click on any footprint to view it in fullscreen.
 
 ### U2, U3, U4 - LM2596S-ADJ Buck Converter
 
-
 ![LM2596S TO-263-5 Package](/footprints/TO-263-5_L10.2-W8.9-P1.70-BR.svg)
 
 **Designators:** U2, U3, U4 (3× units)
@@ -47,7 +44,6 @@ Click on any footprint to view it in fullscreen.
 **Function:** DC-DC conversion (+13.5V, +7.5V, -13.5V outputs)
 
 ### L1, L2, L3 - 100µH Power Inductor
-
 
 ![100µH Power Inductor](/footprints/IND-SMD_L13.8-W12.8.svg)
 
@@ -63,7 +59,6 @@ Click on any footprint to view it in fullscreen.
 
 ### U6 - L7812CD2T-TR (+12V Linear Regulator)
 
-
 ![L7812CD2T TO-263-2 Package](/footprints/TO-263-2_L10.0-W9.1-P5.08-LS15.2-TL.svg)
 
 **Designator:** U6
@@ -74,7 +69,6 @@ Click on any footprint to view it in fullscreen.
 
 ### U7 - L7805ABD2T-TR (+5V Linear Regulator)
 
-
 ![L7805ABD2T TO-263-2 Package](/footprints/TO-263-2_L10.0-W9.2-P5.08-LS15.3-TL-CW.svg)
 
 **Designator:** U7
@@ -84,7 +78,6 @@ Click on any footprint to view it in fullscreen.
 **Function:** Regulates +7.5V to +5V with low noise
 
 ### U8 - CJ7912 (-12V Linear Regulator)
-
 
 ![CJ7912 TO-252-3 Package](/footprints/TO-252-3_L6.5-W5.8-P4.58-BL.svg)
 
@@ -102,7 +95,6 @@ Click on any footprint to view it in fullscreen.
 
 #### 0603 Ceramic Capacitor
 
-
 ![0603 Capacitor](/footprints/C0603.svg)
 
 **Package:** 0603 (1.6mm × 0.8mm)
@@ -115,7 +107,6 @@ Click on any footprint to view it in fullscreen.
 
 #### 0805 Ceramic Capacitor
 
-
 ![0805 Capacitor](/footprints/C0805.svg)
 
 **Package:** 0805 (2.0mm × 1.25mm)
@@ -127,7 +118,6 @@ Click on any footprint to view it in fullscreen.
   **Applications:** Bulk decoupling, output filtering
 
 #### D6.3mm Electrolytic Capacitor
-
 
 ![D6.3mm SMD Electrolytic Capacitor](/footprints/CAP-SMD_BD6.3-L6.6-W6.6-FD.svg)
 
@@ -142,7 +132,6 @@ Click on any footprint to view it in fullscreen.
 
 #### D10mm Electrolytic Capacitor
 
-
 ![D10mm SMD Electrolytic Capacitor](/footprints/CAP-SMD_BD10.0-L10.3-W10.3-LS11.0-FD.svg)
 
 **Package:** SMD Electrolytic (Ø10.0mm, 10.3mm × 10.3mm)
@@ -156,7 +145,6 @@ Click on any footprint to view it in fullscreen.
 
 #### 1206 Ceramic Capacitor
 
-
 ![1206 Capacitor](/footprints/C1206.svg)
 
 **Designator:** C1
@@ -168,7 +156,6 @@ Click on any footprint to view it in fullscreen.
 ### Resistors
 
 #### 0603 Resistor
-
 
 ![0603 Resistor](/footprints/R0603.svg)
 
@@ -184,7 +171,6 @@ Click on any footprint to view it in fullscreen.
 
 #### 0805 Resistor
 
-
 ![0805 Resistor](/footprints/R0805.svg)
 
 **Package:** 0805 (2.0mm × 1.25mm)
@@ -198,7 +184,6 @@ Click on any footprint to view it in fullscreen.
 ### LEDs
 
 #### 0603 LED
-
 
 ![0603 LED](/footprints/LED0603-RD.svg)
 
@@ -219,7 +204,6 @@ Click on any footprint to view it in fullscreen.
 
 #### PTC3 - F1206 (1.5A Hold, -12V Rail)
 
-
 ![1206 PTC Resettable Fuse](/footprints/F1206.svg)
 
 **Designator:** PTC3
@@ -230,7 +214,6 @@ Click on any footprint to view it in fullscreen.
 **Function:** -12V rail auto-reset overcurrent protection
 
 #### PTC1 - F1210 (2.0A Hold, +12V Rail)
-
 
 ![1210 PTC Resettable Fuse](/footprints/F1210.svg)
 
@@ -243,7 +226,6 @@ Click on any footprint to view it in fullscreen.
 
 #### PTC2 - F1812 (1.1A Hold, +5V Rail)
 
-
 ![1812 PTC Resettable Fuse](/footprints/F1812.svg)
 
 **Designator:** PTC2
@@ -254,7 +236,6 @@ Click on any footprint to view it in fullscreen.
 **Function:** +5V rail auto-reset overcurrent protection
 
 ### Schottky Diode (SMA)
-
 
 ![SMA Diode Package](/footprints/SMA_L4.3-W2.6-LS5.2-RD.svg)
 
@@ -268,7 +249,6 @@ Click on any footprint to view it in fullscreen.
 
 #### TVS1, TVS3 - SMAJ15A (±12V Overvoltage Protection)
 
-
 ![SMAJ15A SMA TVS Diode](/footprints/D-FLAT_L4.3-W2.6-LS5.3-RD.svg)
 
 **Designators:** TVS1, TVS3
@@ -279,7 +259,6 @@ Click on any footprint to view it in fullscreen.
 **Function:** Overvoltage protection for ±12V rails
 
 #### TVS2 - SD05 (+5V Overvoltage Protection)
-
 
 ![SD05 SOD-323 TVS Diode](/footprints/SOD-323_L1.8-W1.3-LS2.5-FD.svg)
 
@@ -295,7 +274,6 @@ Click on any footprint to view it in fullscreen.
 
 ### J10-J11 - Eurorack Power Connector (16-pin)
 
-
 ![16-pin 2.54mm Header (Eurorack)](/footprints/HDR-TH_16P-P2.54-H-M-R2-C8-S2.54.svg)
 
 **Designators:** J10, J11 (2× units)
@@ -307,7 +285,6 @@ Click on any footprint to view it in fullscreen.
 **Note:** Standard pin headers. For box/shrouded connectors (commonly used in Eurorack), source the mating connector separately from Tayda Electronics, Mouser, or Digikey.
 
 ### J6-J9 - FASTON 250 Power Terminals
-
 
 ![FASTON 250 PCB Terminal](/footprints/CONN-TH_1217754-1.svg)
 


### PR DESCRIPTION
Closes #98

## Summary

Follow-up to #99 (lefthook + mdx-formatter tooling setup). Runs
`pnpm -C doc run format:md` over the 9 pre-existing files that
`format:md:check` flagged as not matching the formatter's output.

## Changes

- Cosmetic-only: blank-line normalization around headings/lists, fenced code
  block indentation under numbered list items, one frontmatter title unquoted.
- One manual fix on top: in `v4-asbuilt-audit.md` the formatter had split a
  paragraph in a way that left a line starting with `+ ` (renders as a stray
  Markdown list bullet) — rejoined into one flowing paragraph.

## Test Plan

- [x] `pnpm -C doc run format:md:check` — all files pass.
- [x] `pnpm -C doc run check` (typecheck) — passes.
- [x] `pnpm -C doc run build` — 72 pages built successfully.
- [x] Grepped the built HTML for the 3 structurally-risky spots (blank-line
      insertions near list markers) — all render correctly, no stray
      `<ul>`/`<ol>`, the rejoined paragraph is a single `<p>`.
- [x] Opus code-review pass — no issues found.